### PR TITLE
Add tag whitelist and blacklist support

### DIFF
--- a/Loot Generator/loot_generator/data/loot_generator/data/presets.json
+++ b/Loot Generator/loot_generator/data/loot_generator/data/presets.json
@@ -1,9 +1,10 @@
 {
     "Treasure Chest": {
         "loot_points": 50,
-        "tags": [
+        "include_tags": [
             "weapon",
             "magic"
-        ]
+        ],
+        "exclude_tags": []
     }
 }

--- a/Loot Generator/loot_generator/data/presets.json
+++ b/Loot Generator/loot_generator/data/presets.json
@@ -1,9 +1,10 @@
 {
     "Treasure Chest": {
         "loot_points": 50,
-        "tags": [
+        "include_tags": [
             "weapon",
             "magic"
-        ]
+        ],
+        "exclude_tags": []
     }
 }

--- a/Loot Generator/loot_generator/loot_app.pyw
+++ b/Loot Generator/loot_generator/loot_app.pyw
@@ -20,34 +20,39 @@ class LootGeneratorApp:
         self.loot_points_entry = ttk.Entry(frame)
         self.loot_points_entry.grid(row=0, column=1, sticky=tk.EW)
 
-        ttk.Label(frame, text="Tags (comma-separated):").grid(row=1, column=0, sticky=tk.W)
-        self.tags_entry = ttk.Entry(frame)
-        self.tags_entry.grid(row=1, column=1, sticky=tk.EW)
+        ttk.Label(frame, text="Include Tags (comma-separated):").grid(row=1, column=0, sticky=tk.W)
+        self.include_tags_entry = ttk.Entry(frame)
+        self.include_tags_entry.grid(row=1, column=1, sticky=tk.EW)
 
-        ttk.Button(frame, text="Generate Loot", command=self.generate_loot_items).grid(row=2, column=0, columnspan=2, pady=5)
+        ttk.Label(frame, text="Exclude Tags (comma-separated):").grid(row=2, column=0, sticky=tk.W)
+        self.exclude_tags_entry = ttk.Entry(frame)
+        self.exclude_tags_entry.grid(row=2, column=1, sticky=tk.EW)
+
+        ttk.Button(frame, text="Generate Loot", command=self.generate_loot_items).grid(row=3, column=0, columnspan=2, pady=5)
 
         # Preset Controls
-        ttk.Label(frame, text="Preset:").grid(row=3, column=0, sticky=tk.W)
+        ttk.Label(frame, text="Preset:").grid(row=4, column=0, sticky=tk.W)
         self.preset_combo = ttk.Combobox(frame, values=list(self.presets.keys()))
-        self.preset_combo.grid(row=3, column=1, sticky=tk.EW)
+        self.preset_combo.grid(row=4, column=1, sticky=tk.EW)
 
-        ttk.Button(frame, text="Load Preset", command=self.load_preset).grid(row=4, column=0, columnspan=2, pady=5)
-        ttk.Button(frame, text="Save Preset", command=self.save_preset).grid(row=5, column=0, columnspan=2)
-        ttk.Button(frame, text="Delete Preset", command=self.delete_preset).grid(row=6, column=0, columnspan=2)
+        ttk.Button(frame, text="Load Preset", command=self.load_preset).grid(row=5, column=0, columnspan=2, pady=5)
+        ttk.Button(frame, text="Save Preset", command=self.save_preset).grid(row=6, column=0, columnspan=2)
+        ttk.Button(frame, text="Delete Preset", command=self.delete_preset).grid(row=7, column=0, columnspan=2)
 
         # Loot Output
-        ttk.Label(frame, text="Generated Loot:").grid(row=7, column=0, sticky=tk.W)
+        ttk.Label(frame, text="Generated Loot:").grid(row=8, column=0, sticky=tk.W)
         self.output_area = scrolledtext.ScrolledText(frame, height=10)
-        self.output_area.grid(row=8, column=0, columnspan=2, sticky=tk.NSEW, pady=5)
+        self.output_area.grid(row=9, column=0, columnspan=2, sticky=tk.NSEW, pady=5)
 
         frame.columnconfigure(1, weight=1)
-        frame.rowconfigure(8, weight=1)
+        frame.rowconfigure(9, weight=1)
 
     def generate_loot_items(self):
         points = int(self.loot_points_entry.get())
-        tags = [tag.strip() for tag in self.tags_entry.get().split(',')] if self.tags_entry.get() else None
+        include_tags = [tag.strip() for tag in self.include_tags_entry.get().split(',')] if self.include_tags_entry.get() else None
+        exclude_tags = [tag.strip() for tag in self.exclude_tags_entry.get().split(',')] if self.exclude_tags_entry.get() else None
 
-        loot = generate_loot(self.loot_items, points, tags)
+        loot = generate_loot(self.loot_items, points, include_tags, exclude_tags)
 
         self.output_area.delete('1.0', tk.END)
         for item in loot:
@@ -60,8 +65,12 @@ class LootGeneratorApp:
         if preset:
             self.loot_points_entry.delete(0, tk.END)
             self.loot_points_entry.insert(0, str(preset['loot_points']))
-            self.tags_entry.delete(0, tk.END)
-            self.tags_entry.insert(0, ', '.join(preset['tags']))
+            include_tags = preset.get('include_tags', preset.get('tags', []))
+            exclude_tags = preset.get('exclude_tags', [])
+            self.include_tags_entry.delete(0, tk.END)
+            self.include_tags_entry.insert(0, ', '.join(include_tags))
+            self.exclude_tags_entry.delete(0, tk.END)
+            self.exclude_tags_entry.insert(0, ', '.join(exclude_tags))
         else:
             messagebox.showerror("Error", "Preset not found.")
 
@@ -69,9 +78,10 @@ class LootGeneratorApp:
         preset_name = simpledialog.askstring("Save Preset", "Preset Name:")
         if preset_name:
             points = int(self.loot_points_entry.get())
-            tags = [tag.strip() for tag in self.tags_entry.get().split(',')]
+            include_tags = [tag.strip() for tag in self.include_tags_entry.get().split(',') if tag.strip()]
+            exclude_tags = [tag.strip() for tag in self.exclude_tags_entry.get().split(',') if tag.strip()]
 
-            self.presets[preset_name] = {"loot_points": points, "tags": tags}
+            self.presets[preset_name] = {"loot_points": points, "include_tags": include_tags, "exclude_tags": exclude_tags}
             save_presets(self.presets)
             self.preset_combo['values'] = list(self.presets.keys())
             messagebox.showinfo("Saved", f"Preset '{preset_name}' saved successfully!")

--- a/Loot Generator/loot_generator/utils.py
+++ b/Loot Generator/loot_generator/utils.py
@@ -1,7 +1,7 @@
 import json
 import random
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 @dataclass
 class LootItem:
@@ -24,8 +24,12 @@ def save_presets(presets, filepath='data/presets.json'):
     with open(filepath, 'w') as file:
         json.dump(presets, file, indent=4)
 
-def generate_loot(items, points, tags=None):
-    filtered_items = [item for item in items if not tags or set(tags).intersection(item.tags)]
+def generate_loot(items, points, include_tags: Optional[List[str]] = None, exclude_tags: Optional[List[str]] = None):
+    filtered_items = [
+        item for item in items
+        if (not include_tags or set(include_tags).intersection(item.tags))
+        and (not exclude_tags or not set(exclude_tags).intersection(item.tags))
+    ]
     random.shuffle(filtered_items)
 
     loot = []


### PR DESCRIPTION
## Summary
- allow generate_loot() to take include/exclude tag lists
- update GUI with fields for include/exclude tags
- persist new preset format

## Testing
- `python -m py_compile loot_generator/utils.py loot_generator/loot_app.pyw`


------
https://chatgpt.com/codex/tasks/task_e_6841f341373c8329a9c364b6ded2f21d