### PR TITLE
Add tag management and display

### DIFF
--- a/loot_generator/data/loot_items.json
+++ b/loot_generator/data/loot_items.json
@@ -1,23 +1,26 @@
-[
-    {
-        "name": "Steel Sword",
-        "rarity": 1,
-        "description": "A simple but reliable sword.",
-        "point_value": 10,
-        "tags": ["weapon", "melee"]
-    },
-    {
-        "name": "Magic Wand",
-        "rarity": 3,
-        "description": "Channels mysterious energies.",
-        "point_value": 25,
-        "tags": ["weapon", "magic"]
-    },
-    {
-        "name": "Healing Potion",
-        "rarity": 2,
-        "description": "Restores health points.",
-        "point_value": 15,
-        "tags": ["consumable", "magic"]
-    }
-]
+{
+    "items": [
+        {
+            "name": "Steel Sword",
+            "rarity": 1,
+            "description": "A simple but reliable sword.",
+            "point_value": 10,
+            "tags": ["weapon", "melee"]
+        },
+        {
+            "name": "Magic Wand",
+            "rarity": 3,
+            "description": "Channels mysterious energies.",
+            "point_value": 25,
+            "tags": ["weapon", "magic"]
+        },
+        {
+            "name": "Healing Potion",
+            "rarity": 2,
+            "description": "Restores health points.",
+            "point_value": 15,
+            "tags": ["consumable", "magic"]
+        }
+    ],
+    "tags": ["consumable", "magic", "melee", "weapon"]
+}

--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -1,6 +1,14 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, scrolledtext, simpledialog
-from utils import load_loot_items, load_presets, save_presets, generate_loot, LootItem, json
+from utils import (
+    load_loot_items,
+    load_all_tags,
+    load_presets,
+    save_presets,
+    generate_loot,
+    LootItem,
+    json,
+)
 
 
 class LootGeneratorApp:
@@ -8,6 +16,7 @@ class LootGeneratorApp:
         self.root = root
         self.root.title("Loot Generator")
         self.loot_items = load_loot_items()
+        self.all_tags = load_all_tags()
         self.presets = load_presets()
         self.setup_ui()
 
@@ -58,6 +67,8 @@ class LootGeneratorApp:
         # Add/Delete Items
         ttk.Button(frame, text="Add Item", command=self.add_item).grid(row=12, column=0, pady=5)
         ttk.Button(frame, text="Delete Item", command=self.delete_item).grid(row=12, column=1, pady=5)
+
+        ttk.Button(frame, text="Show Tags", command=self.show_tags).grid(row=13, column=0, columnspan=2, pady=5)
 
         frame.columnconfigure(1, weight=1)
         frame.rowconfigure(11, weight=1)
@@ -183,9 +194,20 @@ class LootGeneratorApp:
 
         ttk.Button(delete_window, text="Delete Item", command=confirm_delete).pack(pady=5)
 
+    def update_tag_list(self):
+        self.all_tags = sorted({tag for item in self.loot_items for tag in item.tags})
+
+    def show_tags(self):
+        tags_str = ", ".join(self.all_tags) if self.all_tags else "No tags available"
+        messagebox.showinfo("All Tags", tags_str)
+
     def update_loot_file(self):
+        self.update_tag_list()
         with open('data/loot_items.json', 'w') as file:
-            json.dump([item.__dict__ for item in self.loot_items], file, indent=4)
+            json.dump({
+                "items": [item.__dict__ for item in self.loot_items],
+                "tags": self.all_tags,
+            }, file, indent=4)
 
 if __name__ == "__main__":
     root = tk.Tk()

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 from dataclasses import dataclass
 from typing import List, Optional
@@ -11,17 +12,53 @@ class LootItem:
     point_value: int
     tags: List[str]
 
-def load_loot_items(filepath='data/loot_items.json'):
-    with open(filepath, 'r') as file:
-        items = json.load(file)
-    return [LootItem(**item) for item in items]
+BASE_DIR = os.path.dirname(__file__)
 
-def load_presets(filepath='data/presets.json'):
-    with open(filepath, 'r') as file:
+
+def _resolve(path: str) -> str:
+    """Return absolute path relative to this module."""
+    return os.path.join(BASE_DIR, path)
+
+
+def load_loot_items(filepath=_resolve('data/loot_items.json')):
+    """Load loot items from json file.
+
+    The file may contain either a list of items or an object with
+    ``items`` and ``tags`` keys. Only the item data is returned here.
+    """
+    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'r') as file:
+        data = json.load(file)
+
+    if isinstance(data, dict):
+        items_data = data.get("items", [])
+    else:
+        items_data = data
+
+    return [LootItem(**item) for item in items_data]
+
+def load_all_tags(filepath=_resolve('data/loot_items.json')):
+    """Return the list of all tags stored in ``loot_items.json``.
+
+    For backward compatibility, if the file does not contain a ``tags``
+    key the tags are derived from the items.
+    """
+    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'r') as file:
+        data = json.load(file)
+
+    if isinstance(data, dict) and "tags" in data:
+        return data.get("tags", [])
+
+    # Older format: derive tags from items list
+    items = data if not isinstance(data, dict) else data.get("items", [])
+    tags = sorted({tag for item in items for tag in item.get("tags", [])})
+    return tags
+
+def load_presets(filepath=_resolve('data/presets.json')):
+    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'r') as file:
         return json.load(file)
 
-def save_presets(presets, filepath='data/presets.json'):
-    with open(filepath, 'w') as file:
+def save_presets(presets, filepath=_resolve('data/presets.json')):
+    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'w') as file:
         json.dump(presets, file, indent=4)
 
 def generate_loot(


### PR DESCRIPTION
## Summary
- store unique tag list in `loot_items.json`
- load tags from file and update GUI button to show them
- recalc tag list when adding or removing items
- make data-path handling relative to module

## Testing
- `python -m py_compile loot_generator/utils.py loot_generator/loot_app.pyw`
- *(failed to launch GUI due to no DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc256f4083299191f4070c111dc2