### PR TITLE
Fix path for loot file update

### DIFF
--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -8,6 +8,7 @@ from utils import (
     generate_loot,
     LootItem,
     json,
+    _resolve,
 )
 
 
@@ -203,7 +204,7 @@ class LootGeneratorApp:
 
     def update_loot_file(self):
         self.update_tag_list()
-        with open('data/loot_items.json', 'w') as file:
+        with open(_resolve('data/loot_items.json'), 'w') as file:
             json.dump({
                 "items": [item.__dict__ for item in self.loot_items],
                 "tags": self.all_tags,


### PR DESCRIPTION
## Summary
- import `_resolve` in `loot_app.pyw`
- use `_resolve('data/loot_items.json')` when writing loot data

## Testing
- `python -m py_compile loot_generator/utils.py loot_generator/loot_app.pyw`

------
https://chatgpt.com/codex/tasks/task_e_68420186384483299bada5824e522f40