### PR TITLE
Fix rarity field for adding items

### DIFF
--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -157,7 +157,7 @@ class LootGeneratorApp:
             try:
                 item = LootItem(
                     name=entries["Name"].get(),
-                    rarity=entries["Rarity"].get(),
+                    rarity=int(entries["Rarity (numeric, higher is rarer)"].get()),
                     description=entries["Description"].get(),
                     point_value=int(entries["Point Value"].get()),
                     tags=[tag.strip() for tag in entries["Tags (comma-separated)"].get().split(',')]


### PR DESCRIPTION
## Summary
- fix item addition by using the proper rarity entry

## Testing
- `python -m py_compile loot_generator/loot_app.pyw`
- `python -m py_compile loot_generator/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684201851b388329b92b99b01e5a9910