### PR TITLE
Validate rarity before generating loot

### DIFF
--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -78,6 +78,16 @@ def generate_loot(
         and (max_rarity is None or item.rarity <= max_rarity)
     ]
 
+    # Validate rarities and skip items with non-positive values
+    invalid_items = [item for item in filtered_items if item.rarity <= 0]
+    if invalid_items:
+        filtered_items = [item for item in filtered_items if item.rarity > 0]
+        if not filtered_items:
+            invalid_names = ", ".join(item.name for item in invalid_items)
+            raise ValueError(
+                f"All filtered items have non-positive rarity: {invalid_names}"
+            )
+
     loot = []
     total_points = 0
 


### PR DESCRIPTION
## Summary
- validate item rarity values in `generate_loot`
- skip items with non-positive rarity and raise a helpful error when none remain

## Testing
- `python3 -m py_compile loot_generator/utils.py`
- `python3 -m compileall -q loot_generator`
- manual calls to `generate_loot` with valid and invalid rarities

------
https://chatgpt.com/codex/tasks/task_e_68420a2277ac8329930ada27ae8ac7ac