### PR TITLE
Implement point value validation in generate_loot

### DIFF
--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -88,6 +88,16 @@ def generate_loot(
                 f"All filtered items have non-positive rarity: {invalid_names}"
             )
 
+    # Filter out items with invalid or zero point values
+    invalid_value_items = [item for item in filtered_items if item.point_value <= 0]
+    if invalid_value_items:
+        filtered_items = [item for item in filtered_items if item.point_value > 0]
+        if not filtered_items:
+            invalid_names = ", ".join(item.name for item in invalid_value_items)
+            raise ValueError(
+                f"All filtered items have non-positive point value: {invalid_names}"
+            )
+
     loot = []
     total_points = 0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import random
 import tempfile
+import pytest
 from loot_generator import utils
 
 
@@ -86,3 +87,12 @@ def test_generate_loot_no_items_when_filtered_out():
     random.seed(0)
     loot = utils.generate_loot(items, points=10, include_tags=['nonexistent'])
     assert loot == []
+
+
+def test_generate_loot_invalid_point_values_raise():
+    items = [
+        utils.LootItem('Bad1', 1, '', 0, []),
+        utils.LootItem('Bad2', 1, '', -5, []),
+    ]
+    with pytest.raises(ValueError):
+        utils.generate_loot(items, points=5)


### PR DESCRIPTION
## Summary
- filter items with non-positive point values during loot generation
- raise a `ValueError` when all items are removed for having bad values
- add regression test covering invalid point values

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420c21dbac83298c18898e250c6af3