### PR TITLE
Add large test loot dataset

### DIFF
--- a/loot_generator/data/loot_items.json
+++ b/loot_generator/data/loot_items.json
@@ -1,26 +1,11002 @@
-{
-    "items": [
-        {
-            "name": "Steel Sword",
-            "rarity": 1,
-            "description": "A simple but reliable sword.",
-            "point_value": 10,
-            "tags": ["weapon", "melee"]
-        },
-        {
-            "name": "Magic Wand",
-            "rarity": 3,
-            "description": "Channels mysterious energies.",
-            "point_value": 25,
-            "tags": ["weapon", "magic"]
-        },
-        {
-            "name": "Healing Potion",
-            "rarity": 2,
-            "description": "Restores health points.",
-            "point_value": 15,
-            "tags": ["consumable", "magic"]
-        }
-    ],
-    "tags": ["consumable", "magic", "melee", "weapon"]
-}
+[
+    {
+        "name": "Test 1",
+        "rarity": 7,
+        "description": "Test Item 1",
+        "point_value": 786,
+        "tags": [
+            "large",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 2",
+        "rarity": 8,
+        "description": "Test Item 2",
+        "point_value": 424,
+        "tags": [
+            "medium",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 3",
+        "rarity": 4,
+        "description": "Test Item 3",
+        "point_value": 526,
+        "tags": [
+            "small",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 4",
+        "rarity": 2,
+        "description": "Test Item 4",
+        "point_value": 643,
+        "tags": [
+            "medium",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 5",
+        "rarity": 3,
+        "description": "Test Item 5",
+        "point_value": 327,
+        "tags": [
+            "tiny",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 6",
+        "rarity": 6,
+        "description": "Test Item 6",
+        "point_value": 493,
+        "tags": [
+            "huge",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 7",
+        "rarity": 7,
+        "description": "Test Item 7",
+        "point_value": 333,
+        "tags": [
+            "huge",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 8",
+        "rarity": 8,
+        "description": "Test Item 8",
+        "point_value": 463,
+        "tags": [
+            "huge",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 9",
+        "rarity": 1,
+        "description": "Test Item 9",
+        "point_value": 105,
+        "tags": [
+            "large",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 10",
+        "rarity": 1,
+        "description": "Test Item 10",
+        "point_value": 636,
+        "tags": [
+            "large",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 11",
+        "rarity": 6,
+        "description": "Test Item 11",
+        "point_value": 730,
+        "tags": [
+            "tiny",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 12",
+        "rarity": 4,
+        "description": "Test Item 12",
+        "point_value": 254,
+        "tags": [
+            "small",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 13",
+        "rarity": 2,
+        "description": "Test Item 13",
+        "point_value": 92,
+        "tags": [
+            "medium",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 14",
+        "rarity": 2,
+        "description": "Test Item 14",
+        "point_value": 318,
+        "tags": [
+            "huge",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 15",
+        "rarity": 6,
+        "description": "Test Item 15",
+        "point_value": 844,
+        "tags": [
+            "huge",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 16",
+        "rarity": 5,
+        "description": "Test Item 16",
+        "point_value": 465,
+        "tags": [
+            "tiny",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 17",
+        "rarity": 6,
+        "description": "Test Item 17",
+        "point_value": 599,
+        "tags": [
+            "small",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 18",
+        "rarity": 4,
+        "description": "Test Item 18",
+        "point_value": 851,
+        "tags": [
+            "small",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 19",
+        "rarity": 5,
+        "description": "Test Item 19",
+        "point_value": 497,
+        "tags": [
+            "tiny",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 20",
+        "rarity": 3,
+        "description": "Test Item 20",
+        "point_value": 955,
+        "tags": [
+            "tiny",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 21",
+        "rarity": 7,
+        "description": "Test Item 21",
+        "point_value": 867,
+        "tags": [
+            "huge",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 22",
+        "rarity": 4,
+        "description": "Test Item 22",
+        "point_value": 879,
+        "tags": [
+            "small",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 23",
+        "rarity": 7,
+        "description": "Test Item 23",
+        "point_value": 603,
+        "tags": [
+            "medium",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 24",
+        "rarity": 6,
+        "description": "Test Item 24",
+        "point_value": 94,
+        "tags": [
+            "medium",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 25",
+        "rarity": 8,
+        "description": "Test Item 25",
+        "point_value": 611,
+        "tags": [
+            "medium",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 26",
+        "rarity": 1,
+        "description": "Test Item 26",
+        "point_value": 759,
+        "tags": [
+            "medium",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 27",
+        "rarity": 6,
+        "description": "Test Item 27",
+        "point_value": 823,
+        "tags": [
+            "small",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 28",
+        "rarity": 1,
+        "description": "Test Item 28",
+        "point_value": 113,
+        "tags": [
+            "small",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 29",
+        "rarity": 1,
+        "description": "Test Item 29",
+        "point_value": 846,
+        "tags": [
+            "huge",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 30",
+        "rarity": 2,
+        "description": "Test Item 30",
+        "point_value": 37,
+        "tags": [
+            "tiny",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 31",
+        "rarity": 2,
+        "description": "Test Item 31",
+        "point_value": 410,
+        "tags": [
+            "tiny",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 32",
+        "rarity": 1,
+        "description": "Test Item 32",
+        "point_value": 630,
+        "tags": [
+            "tiny",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 33",
+        "rarity": 2,
+        "description": "Test Item 33",
+        "point_value": 500,
+        "tags": [
+            "small",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 34",
+        "rarity": 1,
+        "description": "Test Item 34",
+        "point_value": 567,
+        "tags": [
+            "large",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 35",
+        "rarity": 5,
+        "description": "Test Item 35",
+        "point_value": 81,
+        "tags": [
+            "small",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 36",
+        "rarity": 5,
+        "description": "Test Item 36",
+        "point_value": 368,
+        "tags": [
+            "large",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 37",
+        "rarity": 8,
+        "description": "Test Item 37",
+        "point_value": 50,
+        "tags": [
+            "huge",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 38",
+        "rarity": 4,
+        "description": "Test Item 38",
+        "point_value": 276,
+        "tags": [
+            "medium",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 39",
+        "rarity": 3,
+        "description": "Test Item 39",
+        "point_value": 724,
+        "tags": [
+            "small",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 40",
+        "rarity": 3,
+        "description": "Test Item 40",
+        "point_value": 360,
+        "tags": [
+            "huge",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 41",
+        "rarity": 8,
+        "description": "Test Item 41",
+        "point_value": 691,
+        "tags": [
+            "small",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 42",
+        "rarity": 7,
+        "description": "Test Item 42",
+        "point_value": 931,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 43",
+        "rarity": 6,
+        "description": "Test Item 43",
+        "point_value": 407,
+        "tags": [
+            "medium",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 44",
+        "rarity": 1,
+        "description": "Test Item 44",
+        "point_value": 478,
+        "tags": [
+            "tiny",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 45",
+        "rarity": 5,
+        "description": "Test Item 45",
+        "point_value": 148,
+        "tags": [
+            "small",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 46",
+        "rarity": 5,
+        "description": "Test Item 46",
+        "point_value": 699,
+        "tags": [
+            "medium",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 47",
+        "rarity": 3,
+        "description": "Test Item 47",
+        "point_value": 742,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 48",
+        "rarity": 2,
+        "description": "Test Item 48",
+        "point_value": 11,
+        "tags": [
+            "huge",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 49",
+        "rarity": 3,
+        "description": "Test Item 49",
+        "point_value": 255,
+        "tags": [
+            "small",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 50",
+        "rarity": 7,
+        "description": "Test Item 50",
+        "point_value": 737,
+        "tags": [
+            "huge",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 51",
+        "rarity": 7,
+        "description": "Test Item 51",
+        "point_value": 902,
+        "tags": [
+            "huge",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 52",
+        "rarity": 3,
+        "description": "Test Item 52",
+        "point_value": 466,
+        "tags": [
+            "tiny",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 53",
+        "rarity": 8,
+        "description": "Test Item 53",
+        "point_value": 550,
+        "tags": [
+            "large",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 54",
+        "rarity": 1,
+        "description": "Test Item 54",
+        "point_value": 915,
+        "tags": [
+            "tiny",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 55",
+        "rarity": 5,
+        "description": "Test Item 55",
+        "point_value": 867,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 56",
+        "rarity": 4,
+        "description": "Test Item 56",
+        "point_value": 571,
+        "tags": [
+            "tiny",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 57",
+        "rarity": 1,
+        "description": "Test Item 57",
+        "point_value": 421,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 58",
+        "rarity": 4,
+        "description": "Test Item 58",
+        "point_value": 24,
+        "tags": [
+            "tiny",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 59",
+        "rarity": 2,
+        "description": "Test Item 59",
+        "point_value": 205,
+        "tags": [
+            "tiny",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 60",
+        "rarity": 4,
+        "description": "Test Item 60",
+        "point_value": 904,
+        "tags": [
+            "medium",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 61",
+        "rarity": 2,
+        "description": "Test Item 61",
+        "point_value": 497,
+        "tags": [
+            "large",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 62",
+        "rarity": 1,
+        "description": "Test Item 62",
+        "point_value": 291,
+        "tags": [
+            "large",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 63",
+        "rarity": 3,
+        "description": "Test Item 63",
+        "point_value": 679,
+        "tags": [
+            "huge",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 64",
+        "rarity": 6,
+        "description": "Test Item 64",
+        "point_value": 127,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 65",
+        "rarity": 1,
+        "description": "Test Item 65",
+        "point_value": 51,
+        "tags": [
+            "small",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 66",
+        "rarity": 6,
+        "description": "Test Item 66",
+        "point_value": 979,
+        "tags": [
+            "medium",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 67",
+        "rarity": 8,
+        "description": "Test Item 67",
+        "point_value": 739,
+        "tags": [
+            "large",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 68",
+        "rarity": 6,
+        "description": "Test Item 68",
+        "point_value": 902,
+        "tags": [
+            "huge",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 69",
+        "rarity": 7,
+        "description": "Test Item 69",
+        "point_value": 611,
+        "tags": [
+            "medium",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 70",
+        "rarity": 3,
+        "description": "Test Item 70",
+        "point_value": 287,
+        "tags": [
+            "medium",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 71",
+        "rarity": 2,
+        "description": "Test Item 71",
+        "point_value": 356,
+        "tags": [
+            "huge",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 72",
+        "rarity": 5,
+        "description": "Test Item 72",
+        "point_value": 177,
+        "tags": [
+            "small",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 73",
+        "rarity": 6,
+        "description": "Test Item 73",
+        "point_value": 414,
+        "tags": [
+            "huge",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 74",
+        "rarity": 2,
+        "description": "Test Item 74",
+        "point_value": 499,
+        "tags": [
+            "small",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 75",
+        "rarity": 3,
+        "description": "Test Item 75",
+        "point_value": 887,
+        "tags": [
+            "huge",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 76",
+        "rarity": 5,
+        "description": "Test Item 76",
+        "point_value": 422,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 77",
+        "rarity": 2,
+        "description": "Test Item 77",
+        "point_value": 111,
+        "tags": [
+            "huge",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 78",
+        "rarity": 6,
+        "description": "Test Item 78",
+        "point_value": 871,
+        "tags": [
+            "medium",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 79",
+        "rarity": 2,
+        "description": "Test Item 79",
+        "point_value": 726,
+        "tags": [
+            "large",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 80",
+        "rarity": 5,
+        "description": "Test Item 80",
+        "point_value": 353,
+        "tags": [
+            "small",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 81",
+        "rarity": 7,
+        "description": "Test Item 81",
+        "point_value": 835,
+        "tags": [
+            "tiny",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 82",
+        "rarity": 4,
+        "description": "Test Item 82",
+        "point_value": 777,
+        "tags": [
+            "small",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 83",
+        "rarity": 1,
+        "description": "Test Item 83",
+        "point_value": 110,
+        "tags": [
+            "large",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 84",
+        "rarity": 5,
+        "description": "Test Item 84",
+        "point_value": 469,
+        "tags": [
+            "large",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 85",
+        "rarity": 7,
+        "description": "Test Item 85",
+        "point_value": 95,
+        "tags": [
+            "medium",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 86",
+        "rarity": 3,
+        "description": "Test Item 86",
+        "point_value": 451,
+        "tags": [
+            "small",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 87",
+        "rarity": 2,
+        "description": "Test Item 87",
+        "point_value": 851,
+        "tags": [
+            "tiny",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 88",
+        "rarity": 4,
+        "description": "Test Item 88",
+        "point_value": 131,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 89",
+        "rarity": 4,
+        "description": "Test Item 89",
+        "point_value": 666,
+        "tags": [
+            "tiny",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 90",
+        "rarity": 3,
+        "description": "Test Item 90",
+        "point_value": 117,
+        "tags": [
+            "small",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 91",
+        "rarity": 6,
+        "description": "Test Item 91",
+        "point_value": 569,
+        "tags": [
+            "small",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 92",
+        "rarity": 8,
+        "description": "Test Item 92",
+        "point_value": 161,
+        "tags": [
+            "huge",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 93",
+        "rarity": 7,
+        "description": "Test Item 93",
+        "point_value": 908,
+        "tags": [
+            "huge",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 94",
+        "rarity": 8,
+        "description": "Test Item 94",
+        "point_value": 520,
+        "tags": [
+            "small",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 95",
+        "rarity": 4,
+        "description": "Test Item 95",
+        "point_value": 19,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 96",
+        "rarity": 6,
+        "description": "Test Item 96",
+        "point_value": 46,
+        "tags": [
+            "huge",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 97",
+        "rarity": 3,
+        "description": "Test Item 97",
+        "point_value": 872,
+        "tags": [
+            "large",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 98",
+        "rarity": 8,
+        "description": "Test Item 98",
+        "point_value": 77,
+        "tags": [
+            "tiny",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 99",
+        "rarity": 2,
+        "description": "Test Item 99",
+        "point_value": 240,
+        "tags": [
+            "small",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 100",
+        "rarity": 1,
+        "description": "Test Item 100",
+        "point_value": 787,
+        "tags": [
+            "large",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 101",
+        "rarity": 3,
+        "description": "Test Item 101",
+        "point_value": 899,
+        "tags": [
+            "large",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 102",
+        "rarity": 7,
+        "description": "Test Item 102",
+        "point_value": 932,
+        "tags": [
+            "huge",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 103",
+        "rarity": 2,
+        "description": "Test Item 103",
+        "point_value": 704,
+        "tags": [
+            "huge",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 104",
+        "rarity": 7,
+        "description": "Test Item 104",
+        "point_value": 937,
+        "tags": [
+            "small",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 105",
+        "rarity": 7,
+        "description": "Test Item 105",
+        "point_value": 855,
+        "tags": [
+            "large",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 106",
+        "rarity": 4,
+        "description": "Test Item 106",
+        "point_value": 881,
+        "tags": [
+            "tiny",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 107",
+        "rarity": 3,
+        "description": "Test Item 107",
+        "point_value": 319,
+        "tags": [
+            "huge",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 108",
+        "rarity": 6,
+        "description": "Test Item 108",
+        "point_value": 77,
+        "tags": [
+            "large",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 109",
+        "rarity": 7,
+        "description": "Test Item 109",
+        "point_value": 403,
+        "tags": [
+            "large",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 110",
+        "rarity": 3,
+        "description": "Test Item 110",
+        "point_value": 254,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 111",
+        "rarity": 1,
+        "description": "Test Item 111",
+        "point_value": 974,
+        "tags": [
+            "tiny",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 112",
+        "rarity": 3,
+        "description": "Test Item 112",
+        "point_value": 513,
+        "tags": [
+            "huge",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 113",
+        "rarity": 3,
+        "description": "Test Item 113",
+        "point_value": 839,
+        "tags": [
+            "medium",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 114",
+        "rarity": 8,
+        "description": "Test Item 114",
+        "point_value": 405,
+        "tags": [
+            "large",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 115",
+        "rarity": 8,
+        "description": "Test Item 115",
+        "point_value": 806,
+        "tags": [
+            "small",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 116",
+        "rarity": 3,
+        "description": "Test Item 116",
+        "point_value": 655,
+        "tags": [
+            "medium",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 117",
+        "rarity": 6,
+        "description": "Test Item 117",
+        "point_value": 209,
+        "tags": [
+            "large",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 118",
+        "rarity": 1,
+        "description": "Test Item 118",
+        "point_value": 634,
+        "tags": [
+            "large",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 119",
+        "rarity": 6,
+        "description": "Test Item 119",
+        "point_value": 676,
+        "tags": [
+            "tiny",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 120",
+        "rarity": 5,
+        "description": "Test Item 120",
+        "point_value": 817,
+        "tags": [
+            "small",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 121",
+        "rarity": 2,
+        "description": "Test Item 121",
+        "point_value": 541,
+        "tags": [
+            "small",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 122",
+        "rarity": 8,
+        "description": "Test Item 122",
+        "point_value": 390,
+        "tags": [
+            "small",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 123",
+        "rarity": 2,
+        "description": "Test Item 123",
+        "point_value": 989,
+        "tags": [
+            "tiny",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 124",
+        "rarity": 5,
+        "description": "Test Item 124",
+        "point_value": 932,
+        "tags": [
+            "tiny",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 125",
+        "rarity": 4,
+        "description": "Test Item 125",
+        "point_value": 245,
+        "tags": [
+            "tiny",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 126",
+        "rarity": 7,
+        "description": "Test Item 126",
+        "point_value": 529,
+        "tags": [
+            "medium",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 127",
+        "rarity": 7,
+        "description": "Test Item 127",
+        "point_value": 923,
+        "tags": [
+            "huge",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 128",
+        "rarity": 2,
+        "description": "Test Item 128",
+        "point_value": 435,
+        "tags": [
+            "tiny",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 129",
+        "rarity": 3,
+        "description": "Test Item 129",
+        "point_value": 761,
+        "tags": [
+            "tiny",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 130",
+        "rarity": 7,
+        "description": "Test Item 130",
+        "point_value": 40,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 131",
+        "rarity": 2,
+        "description": "Test Item 131",
+        "point_value": 370,
+        "tags": [
+            "tiny",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 132",
+        "rarity": 1,
+        "description": "Test Item 132",
+        "point_value": 363,
+        "tags": [
+            "medium",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 133",
+        "rarity": 4,
+        "description": "Test Item 133",
+        "point_value": 848,
+        "tags": [
+            "medium",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 134",
+        "rarity": 3,
+        "description": "Test Item 134",
+        "point_value": 222,
+        "tags": [
+            "tiny",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 135",
+        "rarity": 1,
+        "description": "Test Item 135",
+        "point_value": 15,
+        "tags": [
+            "medium",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 136",
+        "rarity": 4,
+        "description": "Test Item 136",
+        "point_value": 889,
+        "tags": [
+            "small",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 137",
+        "rarity": 2,
+        "description": "Test Item 137",
+        "point_value": 498,
+        "tags": [
+            "medium",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 138",
+        "rarity": 3,
+        "description": "Test Item 138",
+        "point_value": 38,
+        "tags": [
+            "small",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 139",
+        "rarity": 8,
+        "description": "Test Item 139",
+        "point_value": 993,
+        "tags": [
+            "medium",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 140",
+        "rarity": 6,
+        "description": "Test Item 140",
+        "point_value": 198,
+        "tags": [
+            "huge",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 141",
+        "rarity": 5,
+        "description": "Test Item 141",
+        "point_value": 170,
+        "tags": [
+            "large",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 142",
+        "rarity": 4,
+        "description": "Test Item 142",
+        "point_value": 333,
+        "tags": [
+            "huge",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 143",
+        "rarity": 3,
+        "description": "Test Item 143",
+        "point_value": 308,
+        "tags": [
+            "medium",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 144",
+        "rarity": 3,
+        "description": "Test Item 144",
+        "point_value": 625,
+        "tags": [
+            "tiny",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 145",
+        "rarity": 2,
+        "description": "Test Item 145",
+        "point_value": 145,
+        "tags": [
+            "large",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 146",
+        "rarity": 7,
+        "description": "Test Item 146",
+        "point_value": 768,
+        "tags": [
+            "small",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 147",
+        "rarity": 5,
+        "description": "Test Item 147",
+        "point_value": 662,
+        "tags": [
+            "medium",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 148",
+        "rarity": 8,
+        "description": "Test Item 148",
+        "point_value": 657,
+        "tags": [
+            "medium",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 149",
+        "rarity": 1,
+        "description": "Test Item 149",
+        "point_value": 395,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 150",
+        "rarity": 6,
+        "description": "Test Item 150",
+        "point_value": 461,
+        "tags": [
+            "small",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 151",
+        "rarity": 8,
+        "description": "Test Item 151",
+        "point_value": 103,
+        "tags": [
+            "small",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 152",
+        "rarity": 2,
+        "description": "Test Item 152",
+        "point_value": 581,
+        "tags": [
+            "huge",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 153",
+        "rarity": 8,
+        "description": "Test Item 153",
+        "point_value": 960,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 154",
+        "rarity": 7,
+        "description": "Test Item 154",
+        "point_value": 188,
+        "tags": [
+            "small",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 155",
+        "rarity": 3,
+        "description": "Test Item 155",
+        "point_value": 373,
+        "tags": [
+            "large",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 156",
+        "rarity": 2,
+        "description": "Test Item 156",
+        "point_value": 504,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 157",
+        "rarity": 8,
+        "description": "Test Item 157",
+        "point_value": 643,
+        "tags": [
+            "large",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 158",
+        "rarity": 5,
+        "description": "Test Item 158",
+        "point_value": 127,
+        "tags": [
+            "medium",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 159",
+        "rarity": 3,
+        "description": "Test Item 159",
+        "point_value": 444,
+        "tags": [
+            "large",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 160",
+        "rarity": 4,
+        "description": "Test Item 160",
+        "point_value": 566,
+        "tags": [
+            "large",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 161",
+        "rarity": 1,
+        "description": "Test Item 161",
+        "point_value": 133,
+        "tags": [
+            "medium",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 162",
+        "rarity": 1,
+        "description": "Test Item 162",
+        "point_value": 272,
+        "tags": [
+            "large",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 163",
+        "rarity": 7,
+        "description": "Test Item 163",
+        "point_value": 465,
+        "tags": [
+            "tiny",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 164",
+        "rarity": 6,
+        "description": "Test Item 164",
+        "point_value": 300,
+        "tags": [
+            "small",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 165",
+        "rarity": 1,
+        "description": "Test Item 165",
+        "point_value": 82,
+        "tags": [
+            "medium",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 166",
+        "rarity": 6,
+        "description": "Test Item 166",
+        "point_value": 131,
+        "tags": [
+            "huge",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 167",
+        "rarity": 2,
+        "description": "Test Item 167",
+        "point_value": 434,
+        "tags": [
+            "medium",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 168",
+        "rarity": 3,
+        "description": "Test Item 168",
+        "point_value": 597,
+        "tags": [
+            "huge",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 169",
+        "rarity": 2,
+        "description": "Test Item 169",
+        "point_value": 430,
+        "tags": [
+            "huge",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 170",
+        "rarity": 5,
+        "description": "Test Item 170",
+        "point_value": 462,
+        "tags": [
+            "medium",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 171",
+        "rarity": 3,
+        "description": "Test Item 171",
+        "point_value": 170,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 172",
+        "rarity": 7,
+        "description": "Test Item 172",
+        "point_value": 420,
+        "tags": [
+            "huge",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 173",
+        "rarity": 5,
+        "description": "Test Item 173",
+        "point_value": 372,
+        "tags": [
+            "large",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 174",
+        "rarity": 4,
+        "description": "Test Item 174",
+        "point_value": 498,
+        "tags": [
+            "large",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 175",
+        "rarity": 6,
+        "description": "Test Item 175",
+        "point_value": 514,
+        "tags": [
+            "tiny",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 176",
+        "rarity": 3,
+        "description": "Test Item 176",
+        "point_value": 773,
+        "tags": [
+            "large",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 177",
+        "rarity": 4,
+        "description": "Test Item 177",
+        "point_value": 36,
+        "tags": [
+            "medium",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 178",
+        "rarity": 1,
+        "description": "Test Item 178",
+        "point_value": 876,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 179",
+        "rarity": 7,
+        "description": "Test Item 179",
+        "point_value": 16,
+        "tags": [
+            "medium",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 180",
+        "rarity": 1,
+        "description": "Test Item 180",
+        "point_value": 286,
+        "tags": [
+            "medium",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 181",
+        "rarity": 3,
+        "description": "Test Item 181",
+        "point_value": 779,
+        "tags": [
+            "huge",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 182",
+        "rarity": 2,
+        "description": "Test Item 182",
+        "point_value": 454,
+        "tags": [
+            "large",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 183",
+        "rarity": 7,
+        "description": "Test Item 183",
+        "point_value": 182,
+        "tags": [
+            "medium",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 184",
+        "rarity": 7,
+        "description": "Test Item 184",
+        "point_value": 161,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 185",
+        "rarity": 6,
+        "description": "Test Item 185",
+        "point_value": 142,
+        "tags": [
+            "small",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 186",
+        "rarity": 6,
+        "description": "Test Item 186",
+        "point_value": 818,
+        "tags": [
+            "large",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 187",
+        "rarity": 7,
+        "description": "Test Item 187",
+        "point_value": 757,
+        "tags": [
+            "small",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 188",
+        "rarity": 4,
+        "description": "Test Item 188",
+        "point_value": 610,
+        "tags": [
+            "tiny",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 189",
+        "rarity": 4,
+        "description": "Test Item 189",
+        "point_value": 658,
+        "tags": [
+            "tiny",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 190",
+        "rarity": 1,
+        "description": "Test Item 190",
+        "point_value": 770,
+        "tags": [
+            "small",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 191",
+        "rarity": 5,
+        "description": "Test Item 191",
+        "point_value": 637,
+        "tags": [
+            "tiny",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 192",
+        "rarity": 5,
+        "description": "Test Item 192",
+        "point_value": 799,
+        "tags": [
+            "medium",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 193",
+        "rarity": 1,
+        "description": "Test Item 193",
+        "point_value": 657,
+        "tags": [
+            "huge",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 194",
+        "rarity": 7,
+        "description": "Test Item 194",
+        "point_value": 604,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 195",
+        "rarity": 8,
+        "description": "Test Item 195",
+        "point_value": 230,
+        "tags": [
+            "medium",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 196",
+        "rarity": 1,
+        "description": "Test Item 196",
+        "point_value": 63,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 197",
+        "rarity": 5,
+        "description": "Test Item 197",
+        "point_value": 680,
+        "tags": [
+            "tiny",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 198",
+        "rarity": 7,
+        "description": "Test Item 198",
+        "point_value": 706,
+        "tags": [
+            "small",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 199",
+        "rarity": 4,
+        "description": "Test Item 199",
+        "point_value": 474,
+        "tags": [
+            "small",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 200",
+        "rarity": 2,
+        "description": "Test Item 200",
+        "point_value": 630,
+        "tags": [
+            "tiny",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 201",
+        "rarity": 8,
+        "description": "Test Item 201",
+        "point_value": 924,
+        "tags": [
+            "medium",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 202",
+        "rarity": 1,
+        "description": "Test Item 202",
+        "point_value": 204,
+        "tags": [
+            "medium",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 203",
+        "rarity": 6,
+        "description": "Test Item 203",
+        "point_value": 202,
+        "tags": [
+            "small",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 204",
+        "rarity": 5,
+        "description": "Test Item 204",
+        "point_value": 539,
+        "tags": [
+            "large",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 205",
+        "rarity": 6,
+        "description": "Test Item 205",
+        "point_value": 902,
+        "tags": [
+            "small",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 206",
+        "rarity": 2,
+        "description": "Test Item 206",
+        "point_value": 19,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 207",
+        "rarity": 1,
+        "description": "Test Item 207",
+        "point_value": 949,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 208",
+        "rarity": 8,
+        "description": "Test Item 208",
+        "point_value": 130,
+        "tags": [
+            "tiny",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 209",
+        "rarity": 2,
+        "description": "Test Item 209",
+        "point_value": 856,
+        "tags": [
+            "small",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 210",
+        "rarity": 8,
+        "description": "Test Item 210",
+        "point_value": 637,
+        "tags": [
+            "tiny",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 211",
+        "rarity": 7,
+        "description": "Test Item 211",
+        "point_value": 50,
+        "tags": [
+            "small",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 212",
+        "rarity": 4,
+        "description": "Test Item 212",
+        "point_value": 141,
+        "tags": [
+            "medium",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 213",
+        "rarity": 7,
+        "description": "Test Item 213",
+        "point_value": 119,
+        "tags": [
+            "huge",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 214",
+        "rarity": 4,
+        "description": "Test Item 214",
+        "point_value": 738,
+        "tags": [
+            "medium",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 215",
+        "rarity": 8,
+        "description": "Test Item 215",
+        "point_value": 559,
+        "tags": [
+            "medium",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 216",
+        "rarity": 1,
+        "description": "Test Item 216",
+        "point_value": 131,
+        "tags": [
+            "huge",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 217",
+        "rarity": 3,
+        "description": "Test Item 217",
+        "point_value": 760,
+        "tags": [
+            "large",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 218",
+        "rarity": 5,
+        "description": "Test Item 218",
+        "point_value": 910,
+        "tags": [
+            "tiny",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 219",
+        "rarity": 7,
+        "description": "Test Item 219",
+        "point_value": 889,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 220",
+        "rarity": 5,
+        "description": "Test Item 220",
+        "point_value": 131,
+        "tags": [
+            "huge",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 221",
+        "rarity": 5,
+        "description": "Test Item 221",
+        "point_value": 236,
+        "tags": [
+            "small",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 222",
+        "rarity": 5,
+        "description": "Test Item 222",
+        "point_value": 700,
+        "tags": [
+            "medium",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 223",
+        "rarity": 8,
+        "description": "Test Item 223",
+        "point_value": 303,
+        "tags": [
+            "huge",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 224",
+        "rarity": 1,
+        "description": "Test Item 224",
+        "point_value": 576,
+        "tags": [
+            "huge",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 225",
+        "rarity": 1,
+        "description": "Test Item 225",
+        "point_value": 841,
+        "tags": [
+            "small",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 226",
+        "rarity": 3,
+        "description": "Test Item 226",
+        "point_value": 532,
+        "tags": [
+            "tiny",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 227",
+        "rarity": 8,
+        "description": "Test Item 227",
+        "point_value": 593,
+        "tags": [
+            "small",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 228",
+        "rarity": 4,
+        "description": "Test Item 228",
+        "point_value": 788,
+        "tags": [
+            "large",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 229",
+        "rarity": 3,
+        "description": "Test Item 229",
+        "point_value": 654,
+        "tags": [
+            "large",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 230",
+        "rarity": 1,
+        "description": "Test Item 230",
+        "point_value": 549,
+        "tags": [
+            "huge",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 231",
+        "rarity": 8,
+        "description": "Test Item 231",
+        "point_value": 326,
+        "tags": [
+            "tiny",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 232",
+        "rarity": 3,
+        "description": "Test Item 232",
+        "point_value": 686,
+        "tags": [
+            "large",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 233",
+        "rarity": 6,
+        "description": "Test Item 233",
+        "point_value": 731,
+        "tags": [
+            "tiny",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 234",
+        "rarity": 7,
+        "description": "Test Item 234",
+        "point_value": 730,
+        "tags": [
+            "small",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 235",
+        "rarity": 7,
+        "description": "Test Item 235",
+        "point_value": 976,
+        "tags": [
+            "tiny",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 236",
+        "rarity": 6,
+        "description": "Test Item 236",
+        "point_value": 753,
+        "tags": [
+            "small",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 237",
+        "rarity": 4,
+        "description": "Test Item 237",
+        "point_value": 276,
+        "tags": [
+            "medium",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 238",
+        "rarity": 5,
+        "description": "Test Item 238",
+        "point_value": 27,
+        "tags": [
+            "medium",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 239",
+        "rarity": 1,
+        "description": "Test Item 239",
+        "point_value": 759,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 240",
+        "rarity": 8,
+        "description": "Test Item 240",
+        "point_value": 652,
+        "tags": [
+            "tiny",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 241",
+        "rarity": 1,
+        "description": "Test Item 241",
+        "point_value": 22,
+        "tags": [
+            "small",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 242",
+        "rarity": 2,
+        "description": "Test Item 242",
+        "point_value": 850,
+        "tags": [
+            "tiny",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 243",
+        "rarity": 3,
+        "description": "Test Item 243",
+        "point_value": 923,
+        "tags": [
+            "small",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 244",
+        "rarity": 3,
+        "description": "Test Item 244",
+        "point_value": 376,
+        "tags": [
+            "medium",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 245",
+        "rarity": 6,
+        "description": "Test Item 245",
+        "point_value": 755,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 246",
+        "rarity": 7,
+        "description": "Test Item 246",
+        "point_value": 922,
+        "tags": [
+            "medium",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 247",
+        "rarity": 8,
+        "description": "Test Item 247",
+        "point_value": 787,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 248",
+        "rarity": 7,
+        "description": "Test Item 248",
+        "point_value": 986,
+        "tags": [
+            "large",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 249",
+        "rarity": 3,
+        "description": "Test Item 249",
+        "point_value": 646,
+        "tags": [
+            "huge",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 250",
+        "rarity": 2,
+        "description": "Test Item 250",
+        "point_value": 347,
+        "tags": [
+            "small",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 251",
+        "rarity": 1,
+        "description": "Test Item 251",
+        "point_value": 989,
+        "tags": [
+            "small",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 252",
+        "rarity": 3,
+        "description": "Test Item 252",
+        "point_value": 745,
+        "tags": [
+            "tiny",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 253",
+        "rarity": 2,
+        "description": "Test Item 253",
+        "point_value": 645,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 254",
+        "rarity": 1,
+        "description": "Test Item 254",
+        "point_value": 268,
+        "tags": [
+            "medium",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 255",
+        "rarity": 1,
+        "description": "Test Item 255",
+        "point_value": 650,
+        "tags": [
+            "tiny",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 256",
+        "rarity": 6,
+        "description": "Test Item 256",
+        "point_value": 309,
+        "tags": [
+            "small",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 257",
+        "rarity": 6,
+        "description": "Test Item 257",
+        "point_value": 176,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 258",
+        "rarity": 8,
+        "description": "Test Item 258",
+        "point_value": 977,
+        "tags": [
+            "large",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 259",
+        "rarity": 5,
+        "description": "Test Item 259",
+        "point_value": 573,
+        "tags": [
+            "large",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 260",
+        "rarity": 5,
+        "description": "Test Item 260",
+        "point_value": 966,
+        "tags": [
+            "tiny",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 261",
+        "rarity": 2,
+        "description": "Test Item 261",
+        "point_value": 423,
+        "tags": [
+            "medium",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 262",
+        "rarity": 1,
+        "description": "Test Item 262",
+        "point_value": 289,
+        "tags": [
+            "tiny",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 263",
+        "rarity": 5,
+        "description": "Test Item 263",
+        "point_value": 712,
+        "tags": [
+            "small",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 264",
+        "rarity": 6,
+        "description": "Test Item 264",
+        "point_value": 405,
+        "tags": [
+            "medium",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 265",
+        "rarity": 6,
+        "description": "Test Item 265",
+        "point_value": 834,
+        "tags": [
+            "small",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 266",
+        "rarity": 6,
+        "description": "Test Item 266",
+        "point_value": 176,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 267",
+        "rarity": 1,
+        "description": "Test Item 267",
+        "point_value": 588,
+        "tags": [
+            "small",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 268",
+        "rarity": 5,
+        "description": "Test Item 268",
+        "point_value": 650,
+        "tags": [
+            "medium",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 269",
+        "rarity": 7,
+        "description": "Test Item 269",
+        "point_value": 625,
+        "tags": [
+            "large",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 270",
+        "rarity": 3,
+        "description": "Test Item 270",
+        "point_value": 592,
+        "tags": [
+            "tiny",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 271",
+        "rarity": 6,
+        "description": "Test Item 271",
+        "point_value": 961,
+        "tags": [
+            "tiny",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 272",
+        "rarity": 5,
+        "description": "Test Item 272",
+        "point_value": 775,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 273",
+        "rarity": 7,
+        "description": "Test Item 273",
+        "point_value": 295,
+        "tags": [
+            "small",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 274",
+        "rarity": 2,
+        "description": "Test Item 274",
+        "point_value": 684,
+        "tags": [
+            "small",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 275",
+        "rarity": 7,
+        "description": "Test Item 275",
+        "point_value": 782,
+        "tags": [
+            "large",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 276",
+        "rarity": 5,
+        "description": "Test Item 276",
+        "point_value": 23,
+        "tags": [
+            "large",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 277",
+        "rarity": 5,
+        "description": "Test Item 277",
+        "point_value": 560,
+        "tags": [
+            "huge",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 278",
+        "rarity": 6,
+        "description": "Test Item 278",
+        "point_value": 204,
+        "tags": [
+            "large",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 279",
+        "rarity": 3,
+        "description": "Test Item 279",
+        "point_value": 813,
+        "tags": [
+            "huge",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 280",
+        "rarity": 8,
+        "description": "Test Item 280",
+        "point_value": 982,
+        "tags": [
+            "tiny",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 281",
+        "rarity": 4,
+        "description": "Test Item 281",
+        "point_value": 931,
+        "tags": [
+            "tiny",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 282",
+        "rarity": 3,
+        "description": "Test Item 282",
+        "point_value": 706,
+        "tags": [
+            "small",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 283",
+        "rarity": 8,
+        "description": "Test Item 283",
+        "point_value": 29,
+        "tags": [
+            "small",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 284",
+        "rarity": 5,
+        "description": "Test Item 284",
+        "point_value": 199,
+        "tags": [
+            "large",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 285",
+        "rarity": 8,
+        "description": "Test Item 285",
+        "point_value": 252,
+        "tags": [
+            "large",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 286",
+        "rarity": 4,
+        "description": "Test Item 286",
+        "point_value": 178,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 287",
+        "rarity": 7,
+        "description": "Test Item 287",
+        "point_value": 972,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 288",
+        "rarity": 6,
+        "description": "Test Item 288",
+        "point_value": 634,
+        "tags": [
+            "medium",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 289",
+        "rarity": 1,
+        "description": "Test Item 289",
+        "point_value": 514,
+        "tags": [
+            "tiny",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 290",
+        "rarity": 7,
+        "description": "Test Item 290",
+        "point_value": 405,
+        "tags": [
+            "large",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 291",
+        "rarity": 7,
+        "description": "Test Item 291",
+        "point_value": 723,
+        "tags": [
+            "tiny",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 292",
+        "rarity": 6,
+        "description": "Test Item 292",
+        "point_value": 859,
+        "tags": [
+            "huge",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 293",
+        "rarity": 5,
+        "description": "Test Item 293",
+        "point_value": 345,
+        "tags": [
+            "tiny",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 294",
+        "rarity": 3,
+        "description": "Test Item 294",
+        "point_value": 52,
+        "tags": [
+            "tiny",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 295",
+        "rarity": 6,
+        "description": "Test Item 295",
+        "point_value": 14,
+        "tags": [
+            "tiny",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 296",
+        "rarity": 8,
+        "description": "Test Item 296",
+        "point_value": 54,
+        "tags": [
+            "medium",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 297",
+        "rarity": 7,
+        "description": "Test Item 297",
+        "point_value": 936,
+        "tags": [
+            "small",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 298",
+        "rarity": 7,
+        "description": "Test Item 298",
+        "point_value": 696,
+        "tags": [
+            "small",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 299",
+        "rarity": 7,
+        "description": "Test Item 299",
+        "point_value": 897,
+        "tags": [
+            "medium",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 300",
+        "rarity": 3,
+        "description": "Test Item 300",
+        "point_value": 138,
+        "tags": [
+            "small",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 301",
+        "rarity": 1,
+        "description": "Test Item 301",
+        "point_value": 757,
+        "tags": [
+            "huge",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 302",
+        "rarity": 7,
+        "description": "Test Item 302",
+        "point_value": 982,
+        "tags": [
+            "small",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 303",
+        "rarity": 2,
+        "description": "Test Item 303",
+        "point_value": 92,
+        "tags": [
+            "huge",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 304",
+        "rarity": 4,
+        "description": "Test Item 304",
+        "point_value": 829,
+        "tags": [
+            "medium",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 305",
+        "rarity": 5,
+        "description": "Test Item 305",
+        "point_value": 539,
+        "tags": [
+            "large",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 306",
+        "rarity": 3,
+        "description": "Test Item 306",
+        "point_value": 49,
+        "tags": [
+            "huge",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 307",
+        "rarity": 1,
+        "description": "Test Item 307",
+        "point_value": 927,
+        "tags": [
+            "medium",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 308",
+        "rarity": 8,
+        "description": "Test Item 308",
+        "point_value": 635,
+        "tags": [
+            "small",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 309",
+        "rarity": 3,
+        "description": "Test Item 309",
+        "point_value": 736,
+        "tags": [
+            "medium",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 310",
+        "rarity": 8,
+        "description": "Test Item 310",
+        "point_value": 800,
+        "tags": [
+            "huge",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 311",
+        "rarity": 2,
+        "description": "Test Item 311",
+        "point_value": 850,
+        "tags": [
+            "huge",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 312",
+        "rarity": 2,
+        "description": "Test Item 312",
+        "point_value": 116,
+        "tags": [
+            "large",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 313",
+        "rarity": 8,
+        "description": "Test Item 313",
+        "point_value": 353,
+        "tags": [
+            "large",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 314",
+        "rarity": 2,
+        "description": "Test Item 314",
+        "point_value": 149,
+        "tags": [
+            "medium",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 315",
+        "rarity": 3,
+        "description": "Test Item 315",
+        "point_value": 29,
+        "tags": [
+            "medium",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 316",
+        "rarity": 1,
+        "description": "Test Item 316",
+        "point_value": 433,
+        "tags": [
+            "tiny",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 317",
+        "rarity": 7,
+        "description": "Test Item 317",
+        "point_value": 943,
+        "tags": [
+            "tiny",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 318",
+        "rarity": 6,
+        "description": "Test Item 318",
+        "point_value": 950,
+        "tags": [
+            "tiny",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 319",
+        "rarity": 8,
+        "description": "Test Item 319",
+        "point_value": 373,
+        "tags": [
+            "huge",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 320",
+        "rarity": 5,
+        "description": "Test Item 320",
+        "point_value": 586,
+        "tags": [
+            "large",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 321",
+        "rarity": 1,
+        "description": "Test Item 321",
+        "point_value": 474,
+        "tags": [
+            "medium",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 322",
+        "rarity": 2,
+        "description": "Test Item 322",
+        "point_value": 376,
+        "tags": [
+            "tiny",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 323",
+        "rarity": 6,
+        "description": "Test Item 323",
+        "point_value": 31,
+        "tags": [
+            "small",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 324",
+        "rarity": 1,
+        "description": "Test Item 324",
+        "point_value": 340,
+        "tags": [
+            "large",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 325",
+        "rarity": 8,
+        "description": "Test Item 325",
+        "point_value": 92,
+        "tags": [
+            "tiny",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 326",
+        "rarity": 5,
+        "description": "Test Item 326",
+        "point_value": 38,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 327",
+        "rarity": 6,
+        "description": "Test Item 327",
+        "point_value": 377,
+        "tags": [
+            "tiny",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 328",
+        "rarity": 3,
+        "description": "Test Item 328",
+        "point_value": 940,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 329",
+        "rarity": 1,
+        "description": "Test Item 329",
+        "point_value": 10,
+        "tags": [
+            "large",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 330",
+        "rarity": 3,
+        "description": "Test Item 330",
+        "point_value": 174,
+        "tags": [
+            "small",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 331",
+        "rarity": 4,
+        "description": "Test Item 331",
+        "point_value": 975,
+        "tags": [
+            "huge",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 332",
+        "rarity": 8,
+        "description": "Test Item 332",
+        "point_value": 991,
+        "tags": [
+            "large",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 333",
+        "rarity": 4,
+        "description": "Test Item 333",
+        "point_value": 660,
+        "tags": [
+            "medium",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 334",
+        "rarity": 4,
+        "description": "Test Item 334",
+        "point_value": 370,
+        "tags": [
+            "small",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 335",
+        "rarity": 8,
+        "description": "Test Item 335",
+        "point_value": 382,
+        "tags": [
+            "huge",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 336",
+        "rarity": 1,
+        "description": "Test Item 336",
+        "point_value": 176,
+        "tags": [
+            "huge",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 337",
+        "rarity": 3,
+        "description": "Test Item 337",
+        "point_value": 162,
+        "tags": [
+            "tiny",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 338",
+        "rarity": 1,
+        "description": "Test Item 338",
+        "point_value": 49,
+        "tags": [
+            "tiny",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 339",
+        "rarity": 3,
+        "description": "Test Item 339",
+        "point_value": 807,
+        "tags": [
+            "small",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 340",
+        "rarity": 1,
+        "description": "Test Item 340",
+        "point_value": 438,
+        "tags": [
+            "large",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 341",
+        "rarity": 4,
+        "description": "Test Item 341",
+        "point_value": 954,
+        "tags": [
+            "small",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 342",
+        "rarity": 4,
+        "description": "Test Item 342",
+        "point_value": 556,
+        "tags": [
+            "large",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 343",
+        "rarity": 7,
+        "description": "Test Item 343",
+        "point_value": 589,
+        "tags": [
+            "medium",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 344",
+        "rarity": 7,
+        "description": "Test Item 344",
+        "point_value": 261,
+        "tags": [
+            "large",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 345",
+        "rarity": 7,
+        "description": "Test Item 345",
+        "point_value": 255,
+        "tags": [
+            "large",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 346",
+        "rarity": 2,
+        "description": "Test Item 346",
+        "point_value": 865,
+        "tags": [
+            "medium",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 347",
+        "rarity": 6,
+        "description": "Test Item 347",
+        "point_value": 565,
+        "tags": [
+            "tiny",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 348",
+        "rarity": 8,
+        "description": "Test Item 348",
+        "point_value": 907,
+        "tags": [
+            "small",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 349",
+        "rarity": 6,
+        "description": "Test Item 349",
+        "point_value": 898,
+        "tags": [
+            "large",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 350",
+        "rarity": 1,
+        "description": "Test Item 350",
+        "point_value": 157,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 351",
+        "rarity": 7,
+        "description": "Test Item 351",
+        "point_value": 453,
+        "tags": [
+            "tiny",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 352",
+        "rarity": 8,
+        "description": "Test Item 352",
+        "point_value": 175,
+        "tags": [
+            "small",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 353",
+        "rarity": 7,
+        "description": "Test Item 353",
+        "point_value": 172,
+        "tags": [
+            "huge",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 354",
+        "rarity": 2,
+        "description": "Test Item 354",
+        "point_value": 965,
+        "tags": [
+            "medium",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 355",
+        "rarity": 6,
+        "description": "Test Item 355",
+        "point_value": 794,
+        "tags": [
+            "large",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 356",
+        "rarity": 1,
+        "description": "Test Item 356",
+        "point_value": 210,
+        "tags": [
+            "medium",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 357",
+        "rarity": 6,
+        "description": "Test Item 357",
+        "point_value": 313,
+        "tags": [
+            "large",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 358",
+        "rarity": 5,
+        "description": "Test Item 358",
+        "point_value": 574,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 359",
+        "rarity": 5,
+        "description": "Test Item 359",
+        "point_value": 394,
+        "tags": [
+            "small",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 360",
+        "rarity": 3,
+        "description": "Test Item 360",
+        "point_value": 122,
+        "tags": [
+            "huge",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 361",
+        "rarity": 1,
+        "description": "Test Item 361",
+        "point_value": 450,
+        "tags": [
+            "huge",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 362",
+        "rarity": 2,
+        "description": "Test Item 362",
+        "point_value": 667,
+        "tags": [
+            "tiny",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 363",
+        "rarity": 3,
+        "description": "Test Item 363",
+        "point_value": 183,
+        "tags": [
+            "small",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 364",
+        "rarity": 4,
+        "description": "Test Item 364",
+        "point_value": 40,
+        "tags": [
+            "huge",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 365",
+        "rarity": 6,
+        "description": "Test Item 365",
+        "point_value": 931,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 366",
+        "rarity": 6,
+        "description": "Test Item 366",
+        "point_value": 710,
+        "tags": [
+            "tiny",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 367",
+        "rarity": 3,
+        "description": "Test Item 367",
+        "point_value": 360,
+        "tags": [
+            "huge",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 368",
+        "rarity": 3,
+        "description": "Test Item 368",
+        "point_value": 944,
+        "tags": [
+            "large",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 369",
+        "rarity": 5,
+        "description": "Test Item 369",
+        "point_value": 250,
+        "tags": [
+            "large",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 370",
+        "rarity": 8,
+        "description": "Test Item 370",
+        "point_value": 533,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 371",
+        "rarity": 2,
+        "description": "Test Item 371",
+        "point_value": 709,
+        "tags": [
+            "small",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 372",
+        "rarity": 2,
+        "description": "Test Item 372",
+        "point_value": 723,
+        "tags": [
+            "small",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 373",
+        "rarity": 2,
+        "description": "Test Item 373",
+        "point_value": 283,
+        "tags": [
+            "huge",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 374",
+        "rarity": 2,
+        "description": "Test Item 374",
+        "point_value": 822,
+        "tags": [
+            "tiny",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 375",
+        "rarity": 6,
+        "description": "Test Item 375",
+        "point_value": 846,
+        "tags": [
+            "large",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 376",
+        "rarity": 8,
+        "description": "Test Item 376",
+        "point_value": 387,
+        "tags": [
+            "huge",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 377",
+        "rarity": 8,
+        "description": "Test Item 377",
+        "point_value": 841,
+        "tags": [
+            "small",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 378",
+        "rarity": 2,
+        "description": "Test Item 378",
+        "point_value": 809,
+        "tags": [
+            "huge",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 379",
+        "rarity": 3,
+        "description": "Test Item 379",
+        "point_value": 909,
+        "tags": [
+            "huge",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 380",
+        "rarity": 4,
+        "description": "Test Item 380",
+        "point_value": 458,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 381",
+        "rarity": 3,
+        "description": "Test Item 381",
+        "point_value": 951,
+        "tags": [
+            "large",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 382",
+        "rarity": 1,
+        "description": "Test Item 382",
+        "point_value": 948,
+        "tags": [
+            "large",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 383",
+        "rarity": 7,
+        "description": "Test Item 383",
+        "point_value": 352,
+        "tags": [
+            "small",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 384",
+        "rarity": 1,
+        "description": "Test Item 384",
+        "point_value": 501,
+        "tags": [
+            "huge",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 385",
+        "rarity": 8,
+        "description": "Test Item 385",
+        "point_value": 574,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 386",
+        "rarity": 3,
+        "description": "Test Item 386",
+        "point_value": 245,
+        "tags": [
+            "huge",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 387",
+        "rarity": 5,
+        "description": "Test Item 387",
+        "point_value": 882,
+        "tags": [
+            "huge",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 388",
+        "rarity": 2,
+        "description": "Test Item 388",
+        "point_value": 995,
+        "tags": [
+            "tiny",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 389",
+        "rarity": 7,
+        "description": "Test Item 389",
+        "point_value": 579,
+        "tags": [
+            "tiny",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 390",
+        "rarity": 4,
+        "description": "Test Item 390",
+        "point_value": 844,
+        "tags": [
+            "tiny",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 391",
+        "rarity": 6,
+        "description": "Test Item 391",
+        "point_value": 841,
+        "tags": [
+            "tiny",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 392",
+        "rarity": 3,
+        "description": "Test Item 392",
+        "point_value": 610,
+        "tags": [
+            "huge",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 393",
+        "rarity": 1,
+        "description": "Test Item 393",
+        "point_value": 892,
+        "tags": [
+            "large",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 394",
+        "rarity": 8,
+        "description": "Test Item 394",
+        "point_value": 741,
+        "tags": [
+            "tiny",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 395",
+        "rarity": 6,
+        "description": "Test Item 395",
+        "point_value": 905,
+        "tags": [
+            "medium",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 396",
+        "rarity": 4,
+        "description": "Test Item 396",
+        "point_value": 242,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 397",
+        "rarity": 4,
+        "description": "Test Item 397",
+        "point_value": 19,
+        "tags": [
+            "large",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 398",
+        "rarity": 6,
+        "description": "Test Item 398",
+        "point_value": 103,
+        "tags": [
+            "tiny",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 399",
+        "rarity": 7,
+        "description": "Test Item 399",
+        "point_value": 241,
+        "tags": [
+            "medium",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 400",
+        "rarity": 4,
+        "description": "Test Item 400",
+        "point_value": 304,
+        "tags": [
+            "small",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 401",
+        "rarity": 6,
+        "description": "Test Item 401",
+        "point_value": 299,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 402",
+        "rarity": 2,
+        "description": "Test Item 402",
+        "point_value": 420,
+        "tags": [
+            "medium",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 403",
+        "rarity": 4,
+        "description": "Test Item 403",
+        "point_value": 681,
+        "tags": [
+            "medium",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 404",
+        "rarity": 7,
+        "description": "Test Item 404",
+        "point_value": 294,
+        "tags": [
+            "medium",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 405",
+        "rarity": 2,
+        "description": "Test Item 405",
+        "point_value": 501,
+        "tags": [
+            "medium",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 406",
+        "rarity": 3,
+        "description": "Test Item 406",
+        "point_value": 362,
+        "tags": [
+            "small",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 407",
+        "rarity": 6,
+        "description": "Test Item 407",
+        "point_value": 521,
+        "tags": [
+            "small",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 408",
+        "rarity": 7,
+        "description": "Test Item 408",
+        "point_value": 485,
+        "tags": [
+            "huge",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 409",
+        "rarity": 4,
+        "description": "Test Item 409",
+        "point_value": 701,
+        "tags": [
+            "large",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 410",
+        "rarity": 8,
+        "description": "Test Item 410",
+        "point_value": 248,
+        "tags": [
+            "medium",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 411",
+        "rarity": 2,
+        "description": "Test Item 411",
+        "point_value": 493,
+        "tags": [
+            "medium",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 412",
+        "rarity": 7,
+        "description": "Test Item 412",
+        "point_value": 59,
+        "tags": [
+            "huge",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 413",
+        "rarity": 2,
+        "description": "Test Item 413",
+        "point_value": 279,
+        "tags": [
+            "small",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 414",
+        "rarity": 3,
+        "description": "Test Item 414",
+        "point_value": 125,
+        "tags": [
+            "small",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 415",
+        "rarity": 1,
+        "description": "Test Item 415",
+        "point_value": 249,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 416",
+        "rarity": 1,
+        "description": "Test Item 416",
+        "point_value": 142,
+        "tags": [
+            "tiny",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 417",
+        "rarity": 4,
+        "description": "Test Item 417",
+        "point_value": 93,
+        "tags": [
+            "large",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 418",
+        "rarity": 7,
+        "description": "Test Item 418",
+        "point_value": 78,
+        "tags": [
+            "huge",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 419",
+        "rarity": 4,
+        "description": "Test Item 419",
+        "point_value": 960,
+        "tags": [
+            "large",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 420",
+        "rarity": 1,
+        "description": "Test Item 420",
+        "point_value": 456,
+        "tags": [
+            "small",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 421",
+        "rarity": 5,
+        "description": "Test Item 421",
+        "point_value": 39,
+        "tags": [
+            "huge",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 422",
+        "rarity": 6,
+        "description": "Test Item 422",
+        "point_value": 703,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 423",
+        "rarity": 2,
+        "description": "Test Item 423",
+        "point_value": 267,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 424",
+        "rarity": 5,
+        "description": "Test Item 424",
+        "point_value": 34,
+        "tags": [
+            "small",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 425",
+        "rarity": 7,
+        "description": "Test Item 425",
+        "point_value": 222,
+        "tags": [
+            "huge",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 426",
+        "rarity": 4,
+        "description": "Test Item 426",
+        "point_value": 441,
+        "tags": [
+            "huge",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 427",
+        "rarity": 2,
+        "description": "Test Item 427",
+        "point_value": 719,
+        "tags": [
+            "large",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 428",
+        "rarity": 8,
+        "description": "Test Item 428",
+        "point_value": 491,
+        "tags": [
+            "small",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 429",
+        "rarity": 6,
+        "description": "Test Item 429",
+        "point_value": 141,
+        "tags": [
+            "large",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 430",
+        "rarity": 2,
+        "description": "Test Item 430",
+        "point_value": 588,
+        "tags": [
+            "huge",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 431",
+        "rarity": 8,
+        "description": "Test Item 431",
+        "point_value": 264,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 432",
+        "rarity": 1,
+        "description": "Test Item 432",
+        "point_value": 467,
+        "tags": [
+            "tiny",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 433",
+        "rarity": 8,
+        "description": "Test Item 433",
+        "point_value": 239,
+        "tags": [
+            "large",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 434",
+        "rarity": 8,
+        "description": "Test Item 434",
+        "point_value": 496,
+        "tags": [
+            "small",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 435",
+        "rarity": 5,
+        "description": "Test Item 435",
+        "point_value": 378,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 436",
+        "rarity": 2,
+        "description": "Test Item 436",
+        "point_value": 202,
+        "tags": [
+            "medium",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 437",
+        "rarity": 2,
+        "description": "Test Item 437",
+        "point_value": 978,
+        "tags": [
+            "tiny",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 438",
+        "rarity": 1,
+        "description": "Test Item 438",
+        "point_value": 352,
+        "tags": [
+            "huge",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 439",
+        "rarity": 7,
+        "description": "Test Item 439",
+        "point_value": 704,
+        "tags": [
+            "small",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 440",
+        "rarity": 4,
+        "description": "Test Item 440",
+        "point_value": 181,
+        "tags": [
+            "large",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 441",
+        "rarity": 4,
+        "description": "Test Item 441",
+        "point_value": 751,
+        "tags": [
+            "medium",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 442",
+        "rarity": 7,
+        "description": "Test Item 442",
+        "point_value": 165,
+        "tags": [
+            "huge",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 443",
+        "rarity": 4,
+        "description": "Test Item 443",
+        "point_value": 622,
+        "tags": [
+            "large",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 444",
+        "rarity": 8,
+        "description": "Test Item 444",
+        "point_value": 936,
+        "tags": [
+            "huge",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 445",
+        "rarity": 4,
+        "description": "Test Item 445",
+        "point_value": 10,
+        "tags": [
+            "tiny",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 446",
+        "rarity": 4,
+        "description": "Test Item 446",
+        "point_value": 463,
+        "tags": [
+            "huge",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 447",
+        "rarity": 7,
+        "description": "Test Item 447",
+        "point_value": 956,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 448",
+        "rarity": 8,
+        "description": "Test Item 448",
+        "point_value": 711,
+        "tags": [
+            "small",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 449",
+        "rarity": 6,
+        "description": "Test Item 449",
+        "point_value": 744,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 450",
+        "rarity": 6,
+        "description": "Test Item 450",
+        "point_value": 876,
+        "tags": [
+            "large",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 451",
+        "rarity": 4,
+        "description": "Test Item 451",
+        "point_value": 782,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 452",
+        "rarity": 8,
+        "description": "Test Item 452",
+        "point_value": 734,
+        "tags": [
+            "huge",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 453",
+        "rarity": 1,
+        "description": "Test Item 453",
+        "point_value": 31,
+        "tags": [
+            "large",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 454",
+        "rarity": 7,
+        "description": "Test Item 454",
+        "point_value": 609,
+        "tags": [
+            "huge",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 455",
+        "rarity": 4,
+        "description": "Test Item 455",
+        "point_value": 658,
+        "tags": [
+            "tiny",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 456",
+        "rarity": 8,
+        "description": "Test Item 456",
+        "point_value": 326,
+        "tags": [
+            "large",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 457",
+        "rarity": 2,
+        "description": "Test Item 457",
+        "point_value": 90,
+        "tags": [
+            "huge",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 458",
+        "rarity": 1,
+        "description": "Test Item 458",
+        "point_value": 218,
+        "tags": [
+            "large",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 459",
+        "rarity": 5,
+        "description": "Test Item 459",
+        "point_value": 95,
+        "tags": [
+            "tiny",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 460",
+        "rarity": 1,
+        "description": "Test Item 460",
+        "point_value": 612,
+        "tags": [
+            "huge",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 461",
+        "rarity": 8,
+        "description": "Test Item 461",
+        "point_value": 274,
+        "tags": [
+            "tiny",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 462",
+        "rarity": 5,
+        "description": "Test Item 462",
+        "point_value": 909,
+        "tags": [
+            "small",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 463",
+        "rarity": 6,
+        "description": "Test Item 463",
+        "point_value": 243,
+        "tags": [
+            "huge",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 464",
+        "rarity": 1,
+        "description": "Test Item 464",
+        "point_value": 168,
+        "tags": [
+            "medium",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 465",
+        "rarity": 8,
+        "description": "Test Item 465",
+        "point_value": 74,
+        "tags": [
+            "huge",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 466",
+        "rarity": 6,
+        "description": "Test Item 466",
+        "point_value": 404,
+        "tags": [
+            "tiny",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 467",
+        "rarity": 3,
+        "description": "Test Item 467",
+        "point_value": 789,
+        "tags": [
+            "small",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 468",
+        "rarity": 7,
+        "description": "Test Item 468",
+        "point_value": 263,
+        "tags": [
+            "tiny",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 469",
+        "rarity": 5,
+        "description": "Test Item 469",
+        "point_value": 403,
+        "tags": [
+            "tiny",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 470",
+        "rarity": 6,
+        "description": "Test Item 470",
+        "point_value": 640,
+        "tags": [
+            "small",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 471",
+        "rarity": 1,
+        "description": "Test Item 471",
+        "point_value": 356,
+        "tags": [
+            "huge",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 472",
+        "rarity": 3,
+        "description": "Test Item 472",
+        "point_value": 939,
+        "tags": [
+            "large",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 473",
+        "rarity": 5,
+        "description": "Test Item 473",
+        "point_value": 349,
+        "tags": [
+            "small",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 474",
+        "rarity": 7,
+        "description": "Test Item 474",
+        "point_value": 988,
+        "tags": [
+            "tiny",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 475",
+        "rarity": 2,
+        "description": "Test Item 475",
+        "point_value": 543,
+        "tags": [
+            "tiny",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 476",
+        "rarity": 8,
+        "description": "Test Item 476",
+        "point_value": 45,
+        "tags": [
+            "huge",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 477",
+        "rarity": 2,
+        "description": "Test Item 477",
+        "point_value": 581,
+        "tags": [
+            "small",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 478",
+        "rarity": 7,
+        "description": "Test Item 478",
+        "point_value": 216,
+        "tags": [
+            "huge",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 479",
+        "rarity": 6,
+        "description": "Test Item 479",
+        "point_value": 171,
+        "tags": [
+            "medium",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 480",
+        "rarity": 4,
+        "description": "Test Item 480",
+        "point_value": 231,
+        "tags": [
+            "large",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 481",
+        "rarity": 5,
+        "description": "Test Item 481",
+        "point_value": 584,
+        "tags": [
+            "tiny",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 482",
+        "rarity": 5,
+        "description": "Test Item 482",
+        "point_value": 903,
+        "tags": [
+            "medium",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 483",
+        "rarity": 1,
+        "description": "Test Item 483",
+        "point_value": 309,
+        "tags": [
+            "tiny",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 484",
+        "rarity": 4,
+        "description": "Test Item 484",
+        "point_value": 535,
+        "tags": [
+            "huge",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 485",
+        "rarity": 2,
+        "description": "Test Item 485",
+        "point_value": 434,
+        "tags": [
+            "huge",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 486",
+        "rarity": 2,
+        "description": "Test Item 486",
+        "point_value": 92,
+        "tags": [
+            "huge",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 487",
+        "rarity": 3,
+        "description": "Test Item 487",
+        "point_value": 313,
+        "tags": [
+            "small",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 488",
+        "rarity": 5,
+        "description": "Test Item 488",
+        "point_value": 42,
+        "tags": [
+            "tiny",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 489",
+        "rarity": 5,
+        "description": "Test Item 489",
+        "point_value": 88,
+        "tags": [
+            "medium",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 490",
+        "rarity": 5,
+        "description": "Test Item 490",
+        "point_value": 59,
+        "tags": [
+            "small",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 491",
+        "rarity": 3,
+        "description": "Test Item 491",
+        "point_value": 275,
+        "tags": [
+            "huge",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 492",
+        "rarity": 7,
+        "description": "Test Item 492",
+        "point_value": 297,
+        "tags": [
+            "huge",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 493",
+        "rarity": 6,
+        "description": "Test Item 493",
+        "point_value": 942,
+        "tags": [
+            "huge",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 494",
+        "rarity": 2,
+        "description": "Test Item 494",
+        "point_value": 443,
+        "tags": [
+            "medium",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 495",
+        "rarity": 1,
+        "description": "Test Item 495",
+        "point_value": 246,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 496",
+        "rarity": 4,
+        "description": "Test Item 496",
+        "point_value": 93,
+        "tags": [
+            "medium",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 497",
+        "rarity": 3,
+        "description": "Test Item 497",
+        "point_value": 993,
+        "tags": [
+            "large",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 498",
+        "rarity": 7,
+        "description": "Test Item 498",
+        "point_value": 137,
+        "tags": [
+            "huge",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 499",
+        "rarity": 5,
+        "description": "Test Item 499",
+        "point_value": 284,
+        "tags": [
+            "large",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 500",
+        "rarity": 1,
+        "description": "Test Item 500",
+        "point_value": 178,
+        "tags": [
+            "huge",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 501",
+        "rarity": 4,
+        "description": "Test Item 501",
+        "point_value": 164,
+        "tags": [
+            "small",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 502",
+        "rarity": 3,
+        "description": "Test Item 502",
+        "point_value": 574,
+        "tags": [
+            "medium",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 503",
+        "rarity": 3,
+        "description": "Test Item 503",
+        "point_value": 248,
+        "tags": [
+            "large",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 504",
+        "rarity": 4,
+        "description": "Test Item 504",
+        "point_value": 786,
+        "tags": [
+            "huge",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 505",
+        "rarity": 3,
+        "description": "Test Item 505",
+        "point_value": 772,
+        "tags": [
+            "small",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 506",
+        "rarity": 1,
+        "description": "Test Item 506",
+        "point_value": 749,
+        "tags": [
+            "large",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 507",
+        "rarity": 7,
+        "description": "Test Item 507",
+        "point_value": 181,
+        "tags": [
+            "large",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 508",
+        "rarity": 4,
+        "description": "Test Item 508",
+        "point_value": 404,
+        "tags": [
+            "huge",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 509",
+        "rarity": 2,
+        "description": "Test Item 509",
+        "point_value": 139,
+        "tags": [
+            "tiny",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 510",
+        "rarity": 2,
+        "description": "Test Item 510",
+        "point_value": 20,
+        "tags": [
+            "small",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 511",
+        "rarity": 8,
+        "description": "Test Item 511",
+        "point_value": 700,
+        "tags": [
+            "medium",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 512",
+        "rarity": 7,
+        "description": "Test Item 512",
+        "point_value": 274,
+        "tags": [
+            "tiny",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 513",
+        "rarity": 4,
+        "description": "Test Item 513",
+        "point_value": 768,
+        "tags": [
+            "small",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 514",
+        "rarity": 2,
+        "description": "Test Item 514",
+        "point_value": 719,
+        "tags": [
+            "large",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 515",
+        "rarity": 3,
+        "description": "Test Item 515",
+        "point_value": 624,
+        "tags": [
+            "huge",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 516",
+        "rarity": 3,
+        "description": "Test Item 516",
+        "point_value": 369,
+        "tags": [
+            "medium",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 517",
+        "rarity": 5,
+        "description": "Test Item 517",
+        "point_value": 146,
+        "tags": [
+            "tiny",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 518",
+        "rarity": 7,
+        "description": "Test Item 518",
+        "point_value": 357,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 519",
+        "rarity": 3,
+        "description": "Test Item 519",
+        "point_value": 496,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 520",
+        "rarity": 6,
+        "description": "Test Item 520",
+        "point_value": 883,
+        "tags": [
+            "huge",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 521",
+        "rarity": 7,
+        "description": "Test Item 521",
+        "point_value": 722,
+        "tags": [
+            "huge",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 522",
+        "rarity": 4,
+        "description": "Test Item 522",
+        "point_value": 203,
+        "tags": [
+            "large",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 523",
+        "rarity": 3,
+        "description": "Test Item 523",
+        "point_value": 531,
+        "tags": [
+            "small",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 524",
+        "rarity": 8,
+        "description": "Test Item 524",
+        "point_value": 949,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 525",
+        "rarity": 5,
+        "description": "Test Item 525",
+        "point_value": 477,
+        "tags": [
+            "huge",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 526",
+        "rarity": 5,
+        "description": "Test Item 526",
+        "point_value": 479,
+        "tags": [
+            "tiny",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 527",
+        "rarity": 2,
+        "description": "Test Item 527",
+        "point_value": 886,
+        "tags": [
+            "medium",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 528",
+        "rarity": 3,
+        "description": "Test Item 528",
+        "point_value": 642,
+        "tags": [
+            "small",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 529",
+        "rarity": 5,
+        "description": "Test Item 529",
+        "point_value": 19,
+        "tags": [
+            "tiny",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 530",
+        "rarity": 3,
+        "description": "Test Item 530",
+        "point_value": 861,
+        "tags": [
+            "medium",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 531",
+        "rarity": 8,
+        "description": "Test Item 531",
+        "point_value": 766,
+        "tags": [
+            "medium",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 532",
+        "rarity": 7,
+        "description": "Test Item 532",
+        "point_value": 810,
+        "tags": [
+            "tiny",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 533",
+        "rarity": 3,
+        "description": "Test Item 533",
+        "point_value": 24,
+        "tags": [
+            "huge",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 534",
+        "rarity": 6,
+        "description": "Test Item 534",
+        "point_value": 766,
+        "tags": [
+            "small",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 535",
+        "rarity": 6,
+        "description": "Test Item 535",
+        "point_value": 198,
+        "tags": [
+            "small",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 536",
+        "rarity": 7,
+        "description": "Test Item 536",
+        "point_value": 610,
+        "tags": [
+            "small",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 537",
+        "rarity": 7,
+        "description": "Test Item 537",
+        "point_value": 928,
+        "tags": [
+            "huge",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 538",
+        "rarity": 3,
+        "description": "Test Item 538",
+        "point_value": 524,
+        "tags": [
+            "tiny",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 539",
+        "rarity": 6,
+        "description": "Test Item 539",
+        "point_value": 658,
+        "tags": [
+            "huge",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 540",
+        "rarity": 6,
+        "description": "Test Item 540",
+        "point_value": 151,
+        "tags": [
+            "medium",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 541",
+        "rarity": 8,
+        "description": "Test Item 541",
+        "point_value": 502,
+        "tags": [
+            "huge",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 542",
+        "rarity": 2,
+        "description": "Test Item 542",
+        "point_value": 479,
+        "tags": [
+            "small",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 543",
+        "rarity": 5,
+        "description": "Test Item 543",
+        "point_value": 582,
+        "tags": [
+            "large",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 544",
+        "rarity": 7,
+        "description": "Test Item 544",
+        "point_value": 697,
+        "tags": [
+            "small",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 545",
+        "rarity": 3,
+        "description": "Test Item 545",
+        "point_value": 712,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 546",
+        "rarity": 3,
+        "description": "Test Item 546",
+        "point_value": 774,
+        "tags": [
+            "large",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 547",
+        "rarity": 7,
+        "description": "Test Item 547",
+        "point_value": 278,
+        "tags": [
+            "medium",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 548",
+        "rarity": 6,
+        "description": "Test Item 548",
+        "point_value": 531,
+        "tags": [
+            "huge",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 549",
+        "rarity": 1,
+        "description": "Test Item 549",
+        "point_value": 632,
+        "tags": [
+            "tiny",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 550",
+        "rarity": 7,
+        "description": "Test Item 550",
+        "point_value": 404,
+        "tags": [
+            "large",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 551",
+        "rarity": 3,
+        "description": "Test Item 551",
+        "point_value": 97,
+        "tags": [
+            "large",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 552",
+        "rarity": 4,
+        "description": "Test Item 552",
+        "point_value": 59,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 553",
+        "rarity": 1,
+        "description": "Test Item 553",
+        "point_value": 623,
+        "tags": [
+            "large",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 554",
+        "rarity": 5,
+        "description": "Test Item 554",
+        "point_value": 426,
+        "tags": [
+            "large",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 555",
+        "rarity": 8,
+        "description": "Test Item 555",
+        "point_value": 909,
+        "tags": [
+            "huge",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 556",
+        "rarity": 3,
+        "description": "Test Item 556",
+        "point_value": 669,
+        "tags": [
+            "small",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 557",
+        "rarity": 2,
+        "description": "Test Item 557",
+        "point_value": 600,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 558",
+        "rarity": 5,
+        "description": "Test Item 558",
+        "point_value": 226,
+        "tags": [
+            "large",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 559",
+        "rarity": 1,
+        "description": "Test Item 559",
+        "point_value": 546,
+        "tags": [
+            "tiny",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 560",
+        "rarity": 5,
+        "description": "Test Item 560",
+        "point_value": 168,
+        "tags": [
+            "small",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 561",
+        "rarity": 2,
+        "description": "Test Item 561",
+        "point_value": 986,
+        "tags": [
+            "medium",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 562",
+        "rarity": 3,
+        "description": "Test Item 562",
+        "point_value": 348,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 563",
+        "rarity": 6,
+        "description": "Test Item 563",
+        "point_value": 222,
+        "tags": [
+            "medium",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 564",
+        "rarity": 8,
+        "description": "Test Item 564",
+        "point_value": 491,
+        "tags": [
+            "huge",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 565",
+        "rarity": 2,
+        "description": "Test Item 565",
+        "point_value": 333,
+        "tags": [
+            "large",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 566",
+        "rarity": 8,
+        "description": "Test Item 566",
+        "point_value": 574,
+        "tags": [
+            "large",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 567",
+        "rarity": 4,
+        "description": "Test Item 567",
+        "point_value": 157,
+        "tags": [
+            "large",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 568",
+        "rarity": 3,
+        "description": "Test Item 568",
+        "point_value": 910,
+        "tags": [
+            "tiny",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 569",
+        "rarity": 1,
+        "description": "Test Item 569",
+        "point_value": 403,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 570",
+        "rarity": 5,
+        "description": "Test Item 570",
+        "point_value": 588,
+        "tags": [
+            "medium",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 571",
+        "rarity": 7,
+        "description": "Test Item 571",
+        "point_value": 615,
+        "tags": [
+            "medium",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 572",
+        "rarity": 8,
+        "description": "Test Item 572",
+        "point_value": 534,
+        "tags": [
+            "medium",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 573",
+        "rarity": 1,
+        "description": "Test Item 573",
+        "point_value": 752,
+        "tags": [
+            "large",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 574",
+        "rarity": 1,
+        "description": "Test Item 574",
+        "point_value": 265,
+        "tags": [
+            "huge",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 575",
+        "rarity": 2,
+        "description": "Test Item 575",
+        "point_value": 386,
+        "tags": [
+            "large",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 576",
+        "rarity": 1,
+        "description": "Test Item 576",
+        "point_value": 541,
+        "tags": [
+            "huge",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 577",
+        "rarity": 6,
+        "description": "Test Item 577",
+        "point_value": 50,
+        "tags": [
+            "medium",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 578",
+        "rarity": 5,
+        "description": "Test Item 578",
+        "point_value": 507,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 579",
+        "rarity": 4,
+        "description": "Test Item 579",
+        "point_value": 680,
+        "tags": [
+            "large",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 580",
+        "rarity": 3,
+        "description": "Test Item 580",
+        "point_value": 954,
+        "tags": [
+            "tiny",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 581",
+        "rarity": 3,
+        "description": "Test Item 581",
+        "point_value": 863,
+        "tags": [
+            "large",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 582",
+        "rarity": 8,
+        "description": "Test Item 582",
+        "point_value": 228,
+        "tags": [
+            "tiny",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 583",
+        "rarity": 3,
+        "description": "Test Item 583",
+        "point_value": 636,
+        "tags": [
+            "large",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 584",
+        "rarity": 6,
+        "description": "Test Item 584",
+        "point_value": 450,
+        "tags": [
+            "huge",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 585",
+        "rarity": 7,
+        "description": "Test Item 585",
+        "point_value": 410,
+        "tags": [
+            "small",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 586",
+        "rarity": 5,
+        "description": "Test Item 586",
+        "point_value": 256,
+        "tags": [
+            "small",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 587",
+        "rarity": 6,
+        "description": "Test Item 587",
+        "point_value": 974,
+        "tags": [
+            "large",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 588",
+        "rarity": 6,
+        "description": "Test Item 588",
+        "point_value": 648,
+        "tags": [
+            "small",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 589",
+        "rarity": 3,
+        "description": "Test Item 589",
+        "point_value": 874,
+        "tags": [
+            "medium",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 590",
+        "rarity": 2,
+        "description": "Test Item 590",
+        "point_value": 925,
+        "tags": [
+            "large",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 591",
+        "rarity": 3,
+        "description": "Test Item 591",
+        "point_value": 624,
+        "tags": [
+            "medium",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 592",
+        "rarity": 2,
+        "description": "Test Item 592",
+        "point_value": 563,
+        "tags": [
+            "large",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 593",
+        "rarity": 7,
+        "description": "Test Item 593",
+        "point_value": 289,
+        "tags": [
+            "huge",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 594",
+        "rarity": 7,
+        "description": "Test Item 594",
+        "point_value": 332,
+        "tags": [
+            "tiny",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 595",
+        "rarity": 4,
+        "description": "Test Item 595",
+        "point_value": 628,
+        "tags": [
+            "small",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 596",
+        "rarity": 2,
+        "description": "Test Item 596",
+        "point_value": 266,
+        "tags": [
+            "huge",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 597",
+        "rarity": 7,
+        "description": "Test Item 597",
+        "point_value": 843,
+        "tags": [
+            "medium",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 598",
+        "rarity": 1,
+        "description": "Test Item 598",
+        "point_value": 894,
+        "tags": [
+            "tiny",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 599",
+        "rarity": 3,
+        "description": "Test Item 599",
+        "point_value": 791,
+        "tags": [
+            "medium",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 600",
+        "rarity": 8,
+        "description": "Test Item 600",
+        "point_value": 326,
+        "tags": [
+            "huge",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 601",
+        "rarity": 6,
+        "description": "Test Item 601",
+        "point_value": 235,
+        "tags": [
+            "tiny",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 602",
+        "rarity": 2,
+        "description": "Test Item 602",
+        "point_value": 528,
+        "tags": [
+            "tiny",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 603",
+        "rarity": 6,
+        "description": "Test Item 603",
+        "point_value": 988,
+        "tags": [
+            "huge",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 604",
+        "rarity": 4,
+        "description": "Test Item 604",
+        "point_value": 30,
+        "tags": [
+            "tiny",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 605",
+        "rarity": 2,
+        "description": "Test Item 605",
+        "point_value": 845,
+        "tags": [
+            "huge",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 606",
+        "rarity": 4,
+        "description": "Test Item 606",
+        "point_value": 294,
+        "tags": [
+            "medium",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 607",
+        "rarity": 4,
+        "description": "Test Item 607",
+        "point_value": 150,
+        "tags": [
+            "small",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 608",
+        "rarity": 8,
+        "description": "Test Item 608",
+        "point_value": 817,
+        "tags": [
+            "medium",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 609",
+        "rarity": 5,
+        "description": "Test Item 609",
+        "point_value": 219,
+        "tags": [
+            "tiny",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 610",
+        "rarity": 3,
+        "description": "Test Item 610",
+        "point_value": 213,
+        "tags": [
+            "huge",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 611",
+        "rarity": 8,
+        "description": "Test Item 611",
+        "point_value": 704,
+        "tags": [
+            "small",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 612",
+        "rarity": 2,
+        "description": "Test Item 612",
+        "point_value": 929,
+        "tags": [
+            "huge",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 613",
+        "rarity": 4,
+        "description": "Test Item 613",
+        "point_value": 14,
+        "tags": [
+            "small",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 614",
+        "rarity": 1,
+        "description": "Test Item 614",
+        "point_value": 438,
+        "tags": [
+            "small",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 615",
+        "rarity": 1,
+        "description": "Test Item 615",
+        "point_value": 525,
+        "tags": [
+            "medium",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 616",
+        "rarity": 8,
+        "description": "Test Item 616",
+        "point_value": 334,
+        "tags": [
+            "large",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 617",
+        "rarity": 5,
+        "description": "Test Item 617",
+        "point_value": 701,
+        "tags": [
+            "small",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 618",
+        "rarity": 8,
+        "description": "Test Item 618",
+        "point_value": 288,
+        "tags": [
+            "medium",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 619",
+        "rarity": 5,
+        "description": "Test Item 619",
+        "point_value": 233,
+        "tags": [
+            "medium",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 620",
+        "rarity": 2,
+        "description": "Test Item 620",
+        "point_value": 189,
+        "tags": [
+            "large",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 621",
+        "rarity": 2,
+        "description": "Test Item 621",
+        "point_value": 539,
+        "tags": [
+            "small",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 622",
+        "rarity": 3,
+        "description": "Test Item 622",
+        "point_value": 442,
+        "tags": [
+            "medium",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 623",
+        "rarity": 4,
+        "description": "Test Item 623",
+        "point_value": 789,
+        "tags": [
+            "small",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 624",
+        "rarity": 5,
+        "description": "Test Item 624",
+        "point_value": 461,
+        "tags": [
+            "medium",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 625",
+        "rarity": 1,
+        "description": "Test Item 625",
+        "point_value": 362,
+        "tags": [
+            "large",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 626",
+        "rarity": 3,
+        "description": "Test Item 626",
+        "point_value": 800,
+        "tags": [
+            "huge",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 627",
+        "rarity": 1,
+        "description": "Test Item 627",
+        "point_value": 322,
+        "tags": [
+            "huge",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 628",
+        "rarity": 7,
+        "description": "Test Item 628",
+        "point_value": 225,
+        "tags": [
+            "large",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 629",
+        "rarity": 2,
+        "description": "Test Item 629",
+        "point_value": 109,
+        "tags": [
+            "huge",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 630",
+        "rarity": 8,
+        "description": "Test Item 630",
+        "point_value": 777,
+        "tags": [
+            "small",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 631",
+        "rarity": 4,
+        "description": "Test Item 631",
+        "point_value": 256,
+        "tags": [
+            "tiny",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 632",
+        "rarity": 7,
+        "description": "Test Item 632",
+        "point_value": 81,
+        "tags": [
+            "huge",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 633",
+        "rarity": 4,
+        "description": "Test Item 633",
+        "point_value": 233,
+        "tags": [
+            "large",
+            "ancient",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 634",
+        "rarity": 2,
+        "description": "Test Item 634",
+        "point_value": 535,
+        "tags": [
+            "small",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 635",
+        "rarity": 7,
+        "description": "Test Item 635",
+        "point_value": 625,
+        "tags": [
+            "large",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 636",
+        "rarity": 8,
+        "description": "Test Item 636",
+        "point_value": 665,
+        "tags": [
+            "huge",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 637",
+        "rarity": 6,
+        "description": "Test Item 637",
+        "point_value": 797,
+        "tags": [
+            "small",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 638",
+        "rarity": 1,
+        "description": "Test Item 638",
+        "point_value": 212,
+        "tags": [
+            "large",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 639",
+        "rarity": 4,
+        "description": "Test Item 639",
+        "point_value": 855,
+        "tags": [
+            "tiny",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 640",
+        "rarity": 8,
+        "description": "Test Item 640",
+        "point_value": 493,
+        "tags": [
+            "tiny",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 641",
+        "rarity": 5,
+        "description": "Test Item 641",
+        "point_value": 411,
+        "tags": [
+            "medium",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 642",
+        "rarity": 2,
+        "description": "Test Item 642",
+        "point_value": 639,
+        "tags": [
+            "tiny",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 643",
+        "rarity": 2,
+        "description": "Test Item 643",
+        "point_value": 245,
+        "tags": [
+            "small",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 644",
+        "rarity": 1,
+        "description": "Test Item 644",
+        "point_value": 506,
+        "tags": [
+            "medium",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 645",
+        "rarity": 6,
+        "description": "Test Item 645",
+        "point_value": 766,
+        "tags": [
+            "small",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 646",
+        "rarity": 6,
+        "description": "Test Item 646",
+        "point_value": 337,
+        "tags": [
+            "tiny",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 647",
+        "rarity": 4,
+        "description": "Test Item 647",
+        "point_value": 312,
+        "tags": [
+            "huge",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 648",
+        "rarity": 7,
+        "description": "Test Item 648",
+        "point_value": 414,
+        "tags": [
+            "tiny",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 649",
+        "rarity": 2,
+        "description": "Test Item 649",
+        "point_value": 304,
+        "tags": [
+            "small",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 650",
+        "rarity": 8,
+        "description": "Test Item 650",
+        "point_value": 368,
+        "tags": [
+            "small",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 651",
+        "rarity": 7,
+        "description": "Test Item 651",
+        "point_value": 281,
+        "tags": [
+            "small",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 652",
+        "rarity": 3,
+        "description": "Test Item 652",
+        "point_value": 462,
+        "tags": [
+            "huge",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 653",
+        "rarity": 1,
+        "description": "Test Item 653",
+        "point_value": 316,
+        "tags": [
+            "large",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 654",
+        "rarity": 6,
+        "description": "Test Item 654",
+        "point_value": 672,
+        "tags": [
+            "tiny",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 655",
+        "rarity": 4,
+        "description": "Test Item 655",
+        "point_value": 542,
+        "tags": [
+            "tiny",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 656",
+        "rarity": 2,
+        "description": "Test Item 656",
+        "point_value": 486,
+        "tags": [
+            "medium",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 657",
+        "rarity": 5,
+        "description": "Test Item 657",
+        "point_value": 729,
+        "tags": [
+            "huge",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 658",
+        "rarity": 4,
+        "description": "Test Item 658",
+        "point_value": 650,
+        "tags": [
+            "tiny",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 659",
+        "rarity": 3,
+        "description": "Test Item 659",
+        "point_value": 987,
+        "tags": [
+            "large",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 660",
+        "rarity": 4,
+        "description": "Test Item 660",
+        "point_value": 23,
+        "tags": [
+            "small",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 661",
+        "rarity": 3,
+        "description": "Test Item 661",
+        "point_value": 894,
+        "tags": [
+            "small",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 662",
+        "rarity": 3,
+        "description": "Test Item 662",
+        "point_value": 79,
+        "tags": [
+            "tiny",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 663",
+        "rarity": 5,
+        "description": "Test Item 663",
+        "point_value": 647,
+        "tags": [
+            "large",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 664",
+        "rarity": 7,
+        "description": "Test Item 664",
+        "point_value": 52,
+        "tags": [
+            "tiny",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 665",
+        "rarity": 1,
+        "description": "Test Item 665",
+        "point_value": 365,
+        "tags": [
+            "medium",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 666",
+        "rarity": 7,
+        "description": "Test Item 666",
+        "point_value": 409,
+        "tags": [
+            "tiny",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 667",
+        "rarity": 4,
+        "description": "Test Item 667",
+        "point_value": 227,
+        "tags": [
+            "tiny",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 668",
+        "rarity": 4,
+        "description": "Test Item 668",
+        "point_value": 903,
+        "tags": [
+            "huge",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 669",
+        "rarity": 6,
+        "description": "Test Item 669",
+        "point_value": 905,
+        "tags": [
+            "tiny",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 670",
+        "rarity": 3,
+        "description": "Test Item 670",
+        "point_value": 737,
+        "tags": [
+            "medium",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 671",
+        "rarity": 7,
+        "description": "Test Item 671",
+        "point_value": 956,
+        "tags": [
+            "small",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 672",
+        "rarity": 8,
+        "description": "Test Item 672",
+        "point_value": 674,
+        "tags": [
+            "medium",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 673",
+        "rarity": 5,
+        "description": "Test Item 673",
+        "point_value": 934,
+        "tags": [
+            "medium",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 674",
+        "rarity": 3,
+        "description": "Test Item 674",
+        "point_value": 470,
+        "tags": [
+            "tiny",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 675",
+        "rarity": 8,
+        "description": "Test Item 675",
+        "point_value": 63,
+        "tags": [
+            "medium",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 676",
+        "rarity": 7,
+        "description": "Test Item 676",
+        "point_value": 489,
+        "tags": [
+            "huge",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 677",
+        "rarity": 4,
+        "description": "Test Item 677",
+        "point_value": 174,
+        "tags": [
+            "tiny",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 678",
+        "rarity": 7,
+        "description": "Test Item 678",
+        "point_value": 734,
+        "tags": [
+            "medium",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 679",
+        "rarity": 8,
+        "description": "Test Item 679",
+        "point_value": 281,
+        "tags": [
+            "huge",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 680",
+        "rarity": 8,
+        "description": "Test Item 680",
+        "point_value": 284,
+        "tags": [
+            "small",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 681",
+        "rarity": 4,
+        "description": "Test Item 681",
+        "point_value": 357,
+        "tags": [
+            "medium",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 682",
+        "rarity": 1,
+        "description": "Test Item 682",
+        "point_value": 456,
+        "tags": [
+            "medium",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 683",
+        "rarity": 4,
+        "description": "Test Item 683",
+        "point_value": 348,
+        "tags": [
+            "large",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 684",
+        "rarity": 2,
+        "description": "Test Item 684",
+        "point_value": 265,
+        "tags": [
+            "medium",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 685",
+        "rarity": 8,
+        "description": "Test Item 685",
+        "point_value": 187,
+        "tags": [
+            "medium",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 686",
+        "rarity": 7,
+        "description": "Test Item 686",
+        "point_value": 383,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 687",
+        "rarity": 8,
+        "description": "Test Item 687",
+        "point_value": 144,
+        "tags": [
+            "tiny",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 688",
+        "rarity": 7,
+        "description": "Test Item 688",
+        "point_value": 680,
+        "tags": [
+            "large",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 689",
+        "rarity": 2,
+        "description": "Test Item 689",
+        "point_value": 441,
+        "tags": [
+            "tiny",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 690",
+        "rarity": 3,
+        "description": "Test Item 690",
+        "point_value": 318,
+        "tags": [
+            "medium",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 691",
+        "rarity": 6,
+        "description": "Test Item 691",
+        "point_value": 10,
+        "tags": [
+            "small",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 692",
+        "rarity": 6,
+        "description": "Test Item 692",
+        "point_value": 781,
+        "tags": [
+            "medium",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 693",
+        "rarity": 4,
+        "description": "Test Item 693",
+        "point_value": 393,
+        "tags": [
+            "huge",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 694",
+        "rarity": 3,
+        "description": "Test Item 694",
+        "point_value": 970,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 695",
+        "rarity": 2,
+        "description": "Test Item 695",
+        "point_value": 14,
+        "tags": [
+            "tiny",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 696",
+        "rarity": 5,
+        "description": "Test Item 696",
+        "point_value": 567,
+        "tags": [
+            "tiny",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 697",
+        "rarity": 2,
+        "description": "Test Item 697",
+        "point_value": 114,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 698",
+        "rarity": 1,
+        "description": "Test Item 698",
+        "point_value": 261,
+        "tags": [
+            "tiny",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 699",
+        "rarity": 8,
+        "description": "Test Item 699",
+        "point_value": 179,
+        "tags": [
+            "small",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 700",
+        "rarity": 3,
+        "description": "Test Item 700",
+        "point_value": 460,
+        "tags": [
+            "huge",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 701",
+        "rarity": 7,
+        "description": "Test Item 701",
+        "point_value": 26,
+        "tags": [
+            "tiny",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 702",
+        "rarity": 2,
+        "description": "Test Item 702",
+        "point_value": 655,
+        "tags": [
+            "large",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 703",
+        "rarity": 7,
+        "description": "Test Item 703",
+        "point_value": 245,
+        "tags": [
+            "large",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 704",
+        "rarity": 6,
+        "description": "Test Item 704",
+        "point_value": 201,
+        "tags": [
+            "large",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 705",
+        "rarity": 7,
+        "description": "Test Item 705",
+        "point_value": 979,
+        "tags": [
+            "huge",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 706",
+        "rarity": 6,
+        "description": "Test Item 706",
+        "point_value": 535,
+        "tags": [
+            "medium",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 707",
+        "rarity": 8,
+        "description": "Test Item 707",
+        "point_value": 911,
+        "tags": [
+            "medium",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 708",
+        "rarity": 3,
+        "description": "Test Item 708",
+        "point_value": 200,
+        "tags": [
+            "small",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 709",
+        "rarity": 1,
+        "description": "Test Item 709",
+        "point_value": 391,
+        "tags": [
+            "large",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 710",
+        "rarity": 4,
+        "description": "Test Item 710",
+        "point_value": 31,
+        "tags": [
+            "tiny",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 711",
+        "rarity": 3,
+        "description": "Test Item 711",
+        "point_value": 212,
+        "tags": [
+            "large",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 712",
+        "rarity": 6,
+        "description": "Test Item 712",
+        "point_value": 574,
+        "tags": [
+            "small",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 713",
+        "rarity": 7,
+        "description": "Test Item 713",
+        "point_value": 923,
+        "tags": [
+            "large",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 714",
+        "rarity": 1,
+        "description": "Test Item 714",
+        "point_value": 212,
+        "tags": [
+            "huge",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 715",
+        "rarity": 8,
+        "description": "Test Item 715",
+        "point_value": 144,
+        "tags": [
+            "tiny",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 716",
+        "rarity": 7,
+        "description": "Test Item 716",
+        "point_value": 638,
+        "tags": [
+            "medium",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 717",
+        "rarity": 7,
+        "description": "Test Item 717",
+        "point_value": 33,
+        "tags": [
+            "huge",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 718",
+        "rarity": 1,
+        "description": "Test Item 718",
+        "point_value": 212,
+        "tags": [
+            "huge",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 719",
+        "rarity": 8,
+        "description": "Test Item 719",
+        "point_value": 730,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 720",
+        "rarity": 2,
+        "description": "Test Item 720",
+        "point_value": 49,
+        "tags": [
+            "tiny",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 721",
+        "rarity": 7,
+        "description": "Test Item 721",
+        "point_value": 400,
+        "tags": [
+            "small",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 722",
+        "rarity": 7,
+        "description": "Test Item 722",
+        "point_value": 577,
+        "tags": [
+            "tiny",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 723",
+        "rarity": 5,
+        "description": "Test Item 723",
+        "point_value": 699,
+        "tags": [
+            "large",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 724",
+        "rarity": 7,
+        "description": "Test Item 724",
+        "point_value": 949,
+        "tags": [
+            "large",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 725",
+        "rarity": 5,
+        "description": "Test Item 725",
+        "point_value": 490,
+        "tags": [
+            "huge",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 726",
+        "rarity": 7,
+        "description": "Test Item 726",
+        "point_value": 847,
+        "tags": [
+            "huge",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 727",
+        "rarity": 6,
+        "description": "Test Item 727",
+        "point_value": 48,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 728",
+        "rarity": 5,
+        "description": "Test Item 728",
+        "point_value": 77,
+        "tags": [
+            "small",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 729",
+        "rarity": 7,
+        "description": "Test Item 729",
+        "point_value": 34,
+        "tags": [
+            "huge",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 730",
+        "rarity": 3,
+        "description": "Test Item 730",
+        "point_value": 851,
+        "tags": [
+            "large",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 731",
+        "rarity": 3,
+        "description": "Test Item 731",
+        "point_value": 975,
+        "tags": [
+            "huge",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 732",
+        "rarity": 3,
+        "description": "Test Item 732",
+        "point_value": 20,
+        "tags": [
+            "huge",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 733",
+        "rarity": 7,
+        "description": "Test Item 733",
+        "point_value": 193,
+        "tags": [
+            "medium",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 734",
+        "rarity": 5,
+        "description": "Test Item 734",
+        "point_value": 990,
+        "tags": [
+            "huge",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 735",
+        "rarity": 8,
+        "description": "Test Item 735",
+        "point_value": 171,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 736",
+        "rarity": 8,
+        "description": "Test Item 736",
+        "point_value": 844,
+        "tags": [
+            "medium",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 737",
+        "rarity": 5,
+        "description": "Test Item 737",
+        "point_value": 410,
+        "tags": [
+            "tiny",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 738",
+        "rarity": 6,
+        "description": "Test Item 738",
+        "point_value": 788,
+        "tags": [
+            "large",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 739",
+        "rarity": 5,
+        "description": "Test Item 739",
+        "point_value": 235,
+        "tags": [
+            "large",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 740",
+        "rarity": 4,
+        "description": "Test Item 740",
+        "point_value": 396,
+        "tags": [
+            "tiny",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 741",
+        "rarity": 1,
+        "description": "Test Item 741",
+        "point_value": 823,
+        "tags": [
+            "tiny",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 742",
+        "rarity": 5,
+        "description": "Test Item 742",
+        "point_value": 326,
+        "tags": [
+            "tiny",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 743",
+        "rarity": 1,
+        "description": "Test Item 743",
+        "point_value": 169,
+        "tags": [
+            "huge",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 744",
+        "rarity": 2,
+        "description": "Test Item 744",
+        "point_value": 609,
+        "tags": [
+            "small",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 745",
+        "rarity": 3,
+        "description": "Test Item 745",
+        "point_value": 824,
+        "tags": [
+            "tiny",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 746",
+        "rarity": 2,
+        "description": "Test Item 746",
+        "point_value": 216,
+        "tags": [
+            "tiny",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 747",
+        "rarity": 2,
+        "description": "Test Item 747",
+        "point_value": 127,
+        "tags": [
+            "large",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 748",
+        "rarity": 3,
+        "description": "Test Item 748",
+        "point_value": 562,
+        "tags": [
+            "tiny",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 749",
+        "rarity": 7,
+        "description": "Test Item 749",
+        "point_value": 533,
+        "tags": [
+            "small",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 750",
+        "rarity": 1,
+        "description": "Test Item 750",
+        "point_value": 757,
+        "tags": [
+            "huge",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 751",
+        "rarity": 7,
+        "description": "Test Item 751",
+        "point_value": 927,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 752",
+        "rarity": 7,
+        "description": "Test Item 752",
+        "point_value": 940,
+        "tags": [
+            "medium",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 753",
+        "rarity": 2,
+        "description": "Test Item 753",
+        "point_value": 166,
+        "tags": [
+            "huge",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 754",
+        "rarity": 5,
+        "description": "Test Item 754",
+        "point_value": 974,
+        "tags": [
+            "medium",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 755",
+        "rarity": 1,
+        "description": "Test Item 755",
+        "point_value": 18,
+        "tags": [
+            "tiny",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 756",
+        "rarity": 4,
+        "description": "Test Item 756",
+        "point_value": 678,
+        "tags": [
+            "small",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 757",
+        "rarity": 8,
+        "description": "Test Item 757",
+        "point_value": 762,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 758",
+        "rarity": 5,
+        "description": "Test Item 758",
+        "point_value": 999,
+        "tags": [
+            "medium",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 759",
+        "rarity": 3,
+        "description": "Test Item 759",
+        "point_value": 949,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 760",
+        "rarity": 4,
+        "description": "Test Item 760",
+        "point_value": 657,
+        "tags": [
+            "tiny",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 761",
+        "rarity": 3,
+        "description": "Test Item 761",
+        "point_value": 657,
+        "tags": [
+            "medium",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 762",
+        "rarity": 2,
+        "description": "Test Item 762",
+        "point_value": 642,
+        "tags": [
+            "small",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 763",
+        "rarity": 2,
+        "description": "Test Item 763",
+        "point_value": 990,
+        "tags": [
+            "medium",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 764",
+        "rarity": 6,
+        "description": "Test Item 764",
+        "point_value": 42,
+        "tags": [
+            "medium",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 765",
+        "rarity": 1,
+        "description": "Test Item 765",
+        "point_value": 999,
+        "tags": [
+            "large",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 766",
+        "rarity": 3,
+        "description": "Test Item 766",
+        "point_value": 951,
+        "tags": [
+            "medium",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 767",
+        "rarity": 2,
+        "description": "Test Item 767",
+        "point_value": 352,
+        "tags": [
+            "large",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 768",
+        "rarity": 4,
+        "description": "Test Item 768",
+        "point_value": 681,
+        "tags": [
+            "small",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 769",
+        "rarity": 2,
+        "description": "Test Item 769",
+        "point_value": 185,
+        "tags": [
+            "large",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 770",
+        "rarity": 2,
+        "description": "Test Item 770",
+        "point_value": 427,
+        "tags": [
+            "medium",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 771",
+        "rarity": 5,
+        "description": "Test Item 771",
+        "point_value": 15,
+        "tags": [
+            "tiny",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 772",
+        "rarity": 6,
+        "description": "Test Item 772",
+        "point_value": 186,
+        "tags": [
+            "large",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 773",
+        "rarity": 4,
+        "description": "Test Item 773",
+        "point_value": 946,
+        "tags": [
+            "tiny",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 774",
+        "rarity": 4,
+        "description": "Test Item 774",
+        "point_value": 474,
+        "tags": [
+            "huge",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 775",
+        "rarity": 6,
+        "description": "Test Item 775",
+        "point_value": 996,
+        "tags": [
+            "medium",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 776",
+        "rarity": 1,
+        "description": "Test Item 776",
+        "point_value": 438,
+        "tags": [
+            "medium",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 777",
+        "rarity": 4,
+        "description": "Test Item 777",
+        "point_value": 749,
+        "tags": [
+            "large",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 778",
+        "rarity": 4,
+        "description": "Test Item 778",
+        "point_value": 639,
+        "tags": [
+            "large",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 779",
+        "rarity": 3,
+        "description": "Test Item 779",
+        "point_value": 167,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 780",
+        "rarity": 4,
+        "description": "Test Item 780",
+        "point_value": 268,
+        "tags": [
+            "tiny",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 781",
+        "rarity": 1,
+        "description": "Test Item 781",
+        "point_value": 318,
+        "tags": [
+            "small",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 782",
+        "rarity": 5,
+        "description": "Test Item 782",
+        "point_value": 190,
+        "tags": [
+            "large",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 783",
+        "rarity": 7,
+        "description": "Test Item 783",
+        "point_value": 338,
+        "tags": [
+            "huge",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 784",
+        "rarity": 8,
+        "description": "Test Item 784",
+        "point_value": 485,
+        "tags": [
+            "tiny",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 785",
+        "rarity": 6,
+        "description": "Test Item 785",
+        "point_value": 273,
+        "tags": [
+            "medium",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 786",
+        "rarity": 7,
+        "description": "Test Item 786",
+        "point_value": 632,
+        "tags": [
+            "huge",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 787",
+        "rarity": 4,
+        "description": "Test Item 787",
+        "point_value": 442,
+        "tags": [
+            "medium",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 788",
+        "rarity": 7,
+        "description": "Test Item 788",
+        "point_value": 749,
+        "tags": [
+            "tiny",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 789",
+        "rarity": 2,
+        "description": "Test Item 789",
+        "point_value": 984,
+        "tags": [
+            "medium",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 790",
+        "rarity": 1,
+        "description": "Test Item 790",
+        "point_value": 514,
+        "tags": [
+            "large",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 791",
+        "rarity": 8,
+        "description": "Test Item 791",
+        "point_value": 546,
+        "tags": [
+            "large",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 792",
+        "rarity": 3,
+        "description": "Test Item 792",
+        "point_value": 835,
+        "tags": [
+            "huge",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 793",
+        "rarity": 6,
+        "description": "Test Item 793",
+        "point_value": 225,
+        "tags": [
+            "medium",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 794",
+        "rarity": 4,
+        "description": "Test Item 794",
+        "point_value": 109,
+        "tags": [
+            "small",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 795",
+        "rarity": 3,
+        "description": "Test Item 795",
+        "point_value": 966,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 796",
+        "rarity": 3,
+        "description": "Test Item 796",
+        "point_value": 510,
+        "tags": [
+            "medium",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 797",
+        "rarity": 4,
+        "description": "Test Item 797",
+        "point_value": 803,
+        "tags": [
+            "tiny",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 798",
+        "rarity": 5,
+        "description": "Test Item 798",
+        "point_value": 413,
+        "tags": [
+            "huge",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 799",
+        "rarity": 2,
+        "description": "Test Item 799",
+        "point_value": 324,
+        "tags": [
+            "small",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 800",
+        "rarity": 3,
+        "description": "Test Item 800",
+        "point_value": 75,
+        "tags": [
+            "medium",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 801",
+        "rarity": 1,
+        "description": "Test Item 801",
+        "point_value": 511,
+        "tags": [
+            "large",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 802",
+        "rarity": 1,
+        "description": "Test Item 802",
+        "point_value": 152,
+        "tags": [
+            "large",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 803",
+        "rarity": 5,
+        "description": "Test Item 803",
+        "point_value": 92,
+        "tags": [
+            "medium",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 804",
+        "rarity": 8,
+        "description": "Test Item 804",
+        "point_value": 944,
+        "tags": [
+            "medium",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 805",
+        "rarity": 2,
+        "description": "Test Item 805",
+        "point_value": 912,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 806",
+        "rarity": 5,
+        "description": "Test Item 806",
+        "point_value": 683,
+        "tags": [
+            "medium",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 807",
+        "rarity": 3,
+        "description": "Test Item 807",
+        "point_value": 799,
+        "tags": [
+            "tiny",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 808",
+        "rarity": 7,
+        "description": "Test Item 808",
+        "point_value": 424,
+        "tags": [
+            "small",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 809",
+        "rarity": 5,
+        "description": "Test Item 809",
+        "point_value": 976,
+        "tags": [
+            "large",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 810",
+        "rarity": 7,
+        "description": "Test Item 810",
+        "point_value": 158,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 811",
+        "rarity": 4,
+        "description": "Test Item 811",
+        "point_value": 284,
+        "tags": [
+            "tiny",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 812",
+        "rarity": 6,
+        "description": "Test Item 812",
+        "point_value": 381,
+        "tags": [
+            "medium",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 813",
+        "rarity": 4,
+        "description": "Test Item 813",
+        "point_value": 176,
+        "tags": [
+            "large",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 814",
+        "rarity": 4,
+        "description": "Test Item 814",
+        "point_value": 519,
+        "tags": [
+            "small",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 815",
+        "rarity": 8,
+        "description": "Test Item 815",
+        "point_value": 756,
+        "tags": [
+            "medium",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 816",
+        "rarity": 6,
+        "description": "Test Item 816",
+        "point_value": 177,
+        "tags": [
+            "medium",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 817",
+        "rarity": 2,
+        "description": "Test Item 817",
+        "point_value": 397,
+        "tags": [
+            "medium",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 818",
+        "rarity": 6,
+        "description": "Test Item 818",
+        "point_value": 886,
+        "tags": [
+            "tiny",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 819",
+        "rarity": 5,
+        "description": "Test Item 819",
+        "point_value": 664,
+        "tags": [
+            "small",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 820",
+        "rarity": 3,
+        "description": "Test Item 820",
+        "point_value": 496,
+        "tags": [
+            "small",
+            "ancient",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 821",
+        "rarity": 5,
+        "description": "Test Item 821",
+        "point_value": 928,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 822",
+        "rarity": 2,
+        "description": "Test Item 822",
+        "point_value": 410,
+        "tags": [
+            "large",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 823",
+        "rarity": 3,
+        "description": "Test Item 823",
+        "point_value": 69,
+        "tags": [
+            "tiny",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 824",
+        "rarity": 2,
+        "description": "Test Item 824",
+        "point_value": 864,
+        "tags": [
+            "large",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 825",
+        "rarity": 5,
+        "description": "Test Item 825",
+        "point_value": 93,
+        "tags": [
+            "huge",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 826",
+        "rarity": 4,
+        "description": "Test Item 826",
+        "point_value": 883,
+        "tags": [
+            "medium",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 827",
+        "rarity": 8,
+        "description": "Test Item 827",
+        "point_value": 729,
+        "tags": [
+            "medium",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 828",
+        "rarity": 3,
+        "description": "Test Item 828",
+        "point_value": 672,
+        "tags": [
+            "large",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 829",
+        "rarity": 3,
+        "description": "Test Item 829",
+        "point_value": 854,
+        "tags": [
+            "tiny",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 830",
+        "rarity": 6,
+        "description": "Test Item 830",
+        "point_value": 701,
+        "tags": [
+            "large",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 831",
+        "rarity": 6,
+        "description": "Test Item 831",
+        "point_value": 538,
+        "tags": [
+            "large",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 832",
+        "rarity": 1,
+        "description": "Test Item 832",
+        "point_value": 153,
+        "tags": [
+            "medium",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 833",
+        "rarity": 4,
+        "description": "Test Item 833",
+        "point_value": 961,
+        "tags": [
+            "small",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 834",
+        "rarity": 8,
+        "description": "Test Item 834",
+        "point_value": 454,
+        "tags": [
+            "tiny",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 835",
+        "rarity": 2,
+        "description": "Test Item 835",
+        "point_value": 340,
+        "tags": [
+            "small",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 836",
+        "rarity": 6,
+        "description": "Test Item 836",
+        "point_value": 686,
+        "tags": [
+            "large",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 837",
+        "rarity": 8,
+        "description": "Test Item 837",
+        "point_value": 933,
+        "tags": [
+            "huge",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 838",
+        "rarity": 5,
+        "description": "Test Item 838",
+        "point_value": 28,
+        "tags": [
+            "huge",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 839",
+        "rarity": 3,
+        "description": "Test Item 839",
+        "point_value": 15,
+        "tags": [
+            "small",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 840",
+        "rarity": 2,
+        "description": "Test Item 840",
+        "point_value": 329,
+        "tags": [
+            "large",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 841",
+        "rarity": 1,
+        "description": "Test Item 841",
+        "point_value": 476,
+        "tags": [
+            "huge",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 842",
+        "rarity": 7,
+        "description": "Test Item 842",
+        "point_value": 901,
+        "tags": [
+            "large",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 843",
+        "rarity": 6,
+        "description": "Test Item 843",
+        "point_value": 242,
+        "tags": [
+            "medium",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 844",
+        "rarity": 1,
+        "description": "Test Item 844",
+        "point_value": 15,
+        "tags": [
+            "large",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 845",
+        "rarity": 2,
+        "description": "Test Item 845",
+        "point_value": 585,
+        "tags": [
+            "tiny",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 846",
+        "rarity": 1,
+        "description": "Test Item 846",
+        "point_value": 338,
+        "tags": [
+            "medium",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 847",
+        "rarity": 2,
+        "description": "Test Item 847",
+        "point_value": 701,
+        "tags": [
+            "tiny",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 848",
+        "rarity": 6,
+        "description": "Test Item 848",
+        "point_value": 988,
+        "tags": [
+            "large",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 849",
+        "rarity": 6,
+        "description": "Test Item 849",
+        "point_value": 927,
+        "tags": [
+            "large",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 850",
+        "rarity": 1,
+        "description": "Test Item 850",
+        "point_value": 620,
+        "tags": [
+            "small",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 851",
+        "rarity": 8,
+        "description": "Test Item 851",
+        "point_value": 765,
+        "tags": [
+            "tiny",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 852",
+        "rarity": 4,
+        "description": "Test Item 852",
+        "point_value": 74,
+        "tags": [
+            "huge",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 853",
+        "rarity": 6,
+        "description": "Test Item 853",
+        "point_value": 778,
+        "tags": [
+            "medium",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 854",
+        "rarity": 6,
+        "description": "Test Item 854",
+        "point_value": 546,
+        "tags": [
+            "large",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 855",
+        "rarity": 5,
+        "description": "Test Item 855",
+        "point_value": 538,
+        "tags": [
+            "medium",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 856",
+        "rarity": 6,
+        "description": "Test Item 856",
+        "point_value": 420,
+        "tags": [
+            "medium",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 857",
+        "rarity": 1,
+        "description": "Test Item 857",
+        "point_value": 229,
+        "tags": [
+            "large",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 858",
+        "rarity": 7,
+        "description": "Test Item 858",
+        "point_value": 767,
+        "tags": [
+            "small",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 859",
+        "rarity": 4,
+        "description": "Test Item 859",
+        "point_value": 983,
+        "tags": [
+            "small",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 860",
+        "rarity": 2,
+        "description": "Test Item 860",
+        "point_value": 900,
+        "tags": [
+            "medium",
+            "vengu",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 861",
+        "rarity": 3,
+        "description": "Test Item 861",
+        "point_value": 611,
+        "tags": [
+            "small",
+            "vengu",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 862",
+        "rarity": 2,
+        "description": "Test Item 862",
+        "point_value": 502,
+        "tags": [
+            "small",
+            "tribal",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 863",
+        "rarity": 2,
+        "description": "Test Item 863",
+        "point_value": 873,
+        "tags": [
+            "tiny",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 864",
+        "rarity": 2,
+        "description": "Test Item 864",
+        "point_value": 818,
+        "tags": [
+            "tiny",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 865",
+        "rarity": 3,
+        "description": "Test Item 865",
+        "point_value": 586,
+        "tags": [
+            "small",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 866",
+        "rarity": 6,
+        "description": "Test Item 866",
+        "point_value": 112,
+        "tags": [
+            "tiny",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 867",
+        "rarity": 3,
+        "description": "Test Item 867",
+        "point_value": 353,
+        "tags": [
+            "huge",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 868",
+        "rarity": 4,
+        "description": "Test Item 868",
+        "point_value": 791,
+        "tags": [
+            "huge",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 869",
+        "rarity": 5,
+        "description": "Test Item 869",
+        "point_value": 107,
+        "tags": [
+            "small",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 870",
+        "rarity": 4,
+        "description": "Test Item 870",
+        "point_value": 973,
+        "tags": [
+            "small",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 871",
+        "rarity": 5,
+        "description": "Test Item 871",
+        "point_value": 821,
+        "tags": [
+            "medium",
+            "ancient",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 872",
+        "rarity": 6,
+        "description": "Test Item 872",
+        "point_value": 569,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 873",
+        "rarity": 1,
+        "description": "Test Item 873",
+        "point_value": 73,
+        "tags": [
+            "small",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 874",
+        "rarity": 4,
+        "description": "Test Item 874",
+        "point_value": 831,
+        "tags": [
+            "medium",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 875",
+        "rarity": 2,
+        "description": "Test Item 875",
+        "point_value": 346,
+        "tags": [
+            "tiny",
+            "tribal",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 876",
+        "rarity": 8,
+        "description": "Test Item 876",
+        "point_value": 314,
+        "tags": [
+            "small",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 877",
+        "rarity": 6,
+        "description": "Test Item 877",
+        "point_value": 349,
+        "tags": [
+            "small",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 878",
+        "rarity": 5,
+        "description": "Test Item 878",
+        "point_value": 976,
+        "tags": [
+            "large",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 879",
+        "rarity": 3,
+        "description": "Test Item 879",
+        "point_value": 886,
+        "tags": [
+            "small",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 880",
+        "rarity": 6,
+        "description": "Test Item 880",
+        "point_value": 706,
+        "tags": [
+            "large",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 881",
+        "rarity": 7,
+        "description": "Test Item 881",
+        "point_value": 848,
+        "tags": [
+            "medium",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 882",
+        "rarity": 1,
+        "description": "Test Item 882",
+        "point_value": 424,
+        "tags": [
+            "tiny",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 883",
+        "rarity": 3,
+        "description": "Test Item 883",
+        "point_value": 836,
+        "tags": [
+            "medium",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 884",
+        "rarity": 3,
+        "description": "Test Item 884",
+        "point_value": 510,
+        "tags": [
+            "large",
+            "ancient",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 885",
+        "rarity": 6,
+        "description": "Test Item 885",
+        "point_value": 939,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 886",
+        "rarity": 5,
+        "description": "Test Item 886",
+        "point_value": 881,
+        "tags": [
+            "small",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 887",
+        "rarity": 2,
+        "description": "Test Item 887",
+        "point_value": 441,
+        "tags": [
+            "huge",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 888",
+        "rarity": 3,
+        "description": "Test Item 888",
+        "point_value": 939,
+        "tags": [
+            "large",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 889",
+        "rarity": 6,
+        "description": "Test Item 889",
+        "point_value": 615,
+        "tags": [
+            "small",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 890",
+        "rarity": 4,
+        "description": "Test Item 890",
+        "point_value": 125,
+        "tags": [
+            "small",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 891",
+        "rarity": 4,
+        "description": "Test Item 891",
+        "point_value": 38,
+        "tags": [
+            "large",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 892",
+        "rarity": 6,
+        "description": "Test Item 892",
+        "point_value": 614,
+        "tags": [
+            "medium",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 893",
+        "rarity": 1,
+        "description": "Test Item 893",
+        "point_value": 329,
+        "tags": [
+            "large",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 894",
+        "rarity": 8,
+        "description": "Test Item 894",
+        "point_value": 25,
+        "tags": [
+            "huge",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 895",
+        "rarity": 6,
+        "description": "Test Item 895",
+        "point_value": 229,
+        "tags": [
+            "huge",
+            "tribal",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 896",
+        "rarity": 3,
+        "description": "Test Item 896",
+        "point_value": 191,
+        "tags": [
+            "medium",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 897",
+        "rarity": 6,
+        "description": "Test Item 897",
+        "point_value": 763,
+        "tags": [
+            "large",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 898",
+        "rarity": 5,
+        "description": "Test Item 898",
+        "point_value": 737,
+        "tags": [
+            "huge",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 899",
+        "rarity": 1,
+        "description": "Test Item 899",
+        "point_value": 693,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 900",
+        "rarity": 7,
+        "description": "Test Item 900",
+        "point_value": 90,
+        "tags": [
+            "tiny",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 901",
+        "rarity": 4,
+        "description": "Test Item 901",
+        "point_value": 558,
+        "tags": [
+            "tiny",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 902",
+        "rarity": 8,
+        "description": "Test Item 902",
+        "point_value": 581,
+        "tags": [
+            "huge",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 903",
+        "rarity": 3,
+        "description": "Test Item 903",
+        "point_value": 794,
+        "tags": [
+            "huge",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 904",
+        "rarity": 1,
+        "description": "Test Item 904",
+        "point_value": 905,
+        "tags": [
+            "large",
+            "tribal",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 905",
+        "rarity": 1,
+        "description": "Test Item 905",
+        "point_value": 515,
+        "tags": [
+            "tiny",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 906",
+        "rarity": 1,
+        "description": "Test Item 906",
+        "point_value": 618,
+        "tags": [
+            "small",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 907",
+        "rarity": 4,
+        "description": "Test Item 907",
+        "point_value": 543,
+        "tags": [
+            "medium",
+            "vengu",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 908",
+        "rarity": 2,
+        "description": "Test Item 908",
+        "point_value": 163,
+        "tags": [
+            "medium",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 909",
+        "rarity": 6,
+        "description": "Test Item 909",
+        "point_value": 681,
+        "tags": [
+            "medium",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 910",
+        "rarity": 5,
+        "description": "Test Item 910",
+        "point_value": 22,
+        "tags": [
+            "huge",
+            "tribal",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 911",
+        "rarity": 2,
+        "description": "Test Item 911",
+        "point_value": 346,
+        "tags": [
+            "medium",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 912",
+        "rarity": 5,
+        "description": "Test Item 912",
+        "point_value": 587,
+        "tags": [
+            "small",
+            "tribal",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 913",
+        "rarity": 1,
+        "description": "Test Item 913",
+        "point_value": 867,
+        "tags": [
+            "huge",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 914",
+        "rarity": 7,
+        "description": "Test Item 914",
+        "point_value": 249,
+        "tags": [
+            "large",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 915",
+        "rarity": 5,
+        "description": "Test Item 915",
+        "point_value": 842,
+        "tags": [
+            "tiny",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 916",
+        "rarity": 8,
+        "description": "Test Item 916",
+        "point_value": 560,
+        "tags": [
+            "tiny",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 917",
+        "rarity": 1,
+        "description": "Test Item 917",
+        "point_value": 826,
+        "tags": [
+            "tiny",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 918",
+        "rarity": 7,
+        "description": "Test Item 918",
+        "point_value": 622,
+        "tags": [
+            "small",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 919",
+        "rarity": 2,
+        "description": "Test Item 919",
+        "point_value": 40,
+        "tags": [
+            "tiny",
+            "tribal",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 920",
+        "rarity": 5,
+        "description": "Test Item 920",
+        "point_value": 185,
+        "tags": [
+            "large",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 921",
+        "rarity": 7,
+        "description": "Test Item 921",
+        "point_value": 541,
+        "tags": [
+            "small",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 922",
+        "rarity": 4,
+        "description": "Test Item 922",
+        "point_value": 703,
+        "tags": [
+            "tiny",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 923",
+        "rarity": 1,
+        "description": "Test Item 923",
+        "point_value": 867,
+        "tags": [
+            "small",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 924",
+        "rarity": 3,
+        "description": "Test Item 924",
+        "point_value": 591,
+        "tags": [
+            "small",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 925",
+        "rarity": 4,
+        "description": "Test Item 925",
+        "point_value": 132,
+        "tags": [
+            "medium",
+            "tribal",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 926",
+        "rarity": 5,
+        "description": "Test Item 926",
+        "point_value": 823,
+        "tags": [
+            "small",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 927",
+        "rarity": 7,
+        "description": "Test Item 927",
+        "point_value": 292,
+        "tags": [
+            "tiny",
+            "tribal",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 928",
+        "rarity": 8,
+        "description": "Test Item 928",
+        "point_value": 176,
+        "tags": [
+            "large",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 929",
+        "rarity": 7,
+        "description": "Test Item 929",
+        "point_value": 141,
+        "tags": [
+            "huge",
+            "vengu",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 930",
+        "rarity": 6,
+        "description": "Test Item 930",
+        "point_value": 951,
+        "tags": [
+            "tiny",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 931",
+        "rarity": 4,
+        "description": "Test Item 931",
+        "point_value": 231,
+        "tags": [
+            "huge",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 932",
+        "rarity": 4,
+        "description": "Test Item 932",
+        "point_value": 595,
+        "tags": [
+            "tiny",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 933",
+        "rarity": 3,
+        "description": "Test Item 933",
+        "point_value": 910,
+        "tags": [
+            "small",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 934",
+        "rarity": 6,
+        "description": "Test Item 934",
+        "point_value": 126,
+        "tags": [
+            "small",
+            "vengu",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 935",
+        "rarity": 3,
+        "description": "Test Item 935",
+        "point_value": 569,
+        "tags": [
+            "large",
+            "tribal",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 936",
+        "rarity": 6,
+        "description": "Test Item 936",
+        "point_value": 151,
+        "tags": [
+            "tiny",
+            "vengu",
+            "container"
+        ]
+    },
+    {
+        "name": "Test 937",
+        "rarity": 8,
+        "description": "Test Item 937",
+        "point_value": 693,
+        "tags": [
+            "huge",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 938",
+        "rarity": 1,
+        "description": "Test Item 938",
+        "point_value": 779,
+        "tags": [
+            "small",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 939",
+        "rarity": 4,
+        "description": "Test Item 939",
+        "point_value": 355,
+        "tags": [
+            "tiny",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 940",
+        "rarity": 8,
+        "description": "Test Item 940",
+        "point_value": 390,
+        "tags": [
+            "medium",
+            "ancient",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 941",
+        "rarity": 2,
+        "description": "Test Item 941",
+        "point_value": 377,
+        "tags": [
+            "medium",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 942",
+        "rarity": 4,
+        "description": "Test Item 942",
+        "point_value": 256,
+        "tags": [
+            "small",
+            "ancient",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 943",
+        "rarity": 2,
+        "description": "Test Item 943",
+        "point_value": 557,
+        "tags": [
+            "medium",
+            "vengu",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 944",
+        "rarity": 6,
+        "description": "Test Item 944",
+        "point_value": 935,
+        "tags": [
+            "large",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 945",
+        "rarity": 1,
+        "description": "Test Item 945",
+        "point_value": 557,
+        "tags": [
+            "large",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 946",
+        "rarity": 5,
+        "description": "Test Item 946",
+        "point_value": 833,
+        "tags": [
+            "small",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 947",
+        "rarity": 2,
+        "description": "Test Item 947",
+        "point_value": 930,
+        "tags": [
+            "tiny",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 948",
+        "rarity": 6,
+        "description": "Test Item 948",
+        "point_value": 193,
+        "tags": [
+            "small",
+            "ancient",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 949",
+        "rarity": 5,
+        "description": "Test Item 949",
+        "point_value": 188,
+        "tags": [
+            "large",
+            "tribal",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 950",
+        "rarity": 4,
+        "description": "Test Item 950",
+        "point_value": 89,
+        "tags": [
+            "large",
+            "ancient",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 951",
+        "rarity": 7,
+        "description": "Test Item 951",
+        "point_value": 285,
+        "tags": [
+            "medium",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 952",
+        "rarity": 8,
+        "description": "Test Item 952",
+        "point_value": 846,
+        "tags": [
+            "medium",
+            "vengu",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 953",
+        "rarity": 2,
+        "description": "Test Item 953",
+        "point_value": 966,
+        "tags": [
+            "large",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 954",
+        "rarity": 6,
+        "description": "Test Item 954",
+        "point_value": 851,
+        "tags": [
+            "huge",
+            "tribal",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 955",
+        "rarity": 3,
+        "description": "Test Item 955",
+        "point_value": 300,
+        "tags": [
+            "tiny",
+            "tribal",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 956",
+        "rarity": 8,
+        "description": "Test Item 956",
+        "point_value": 617,
+        "tags": [
+            "small",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 957",
+        "rarity": 7,
+        "description": "Test Item 957",
+        "point_value": 246,
+        "tags": [
+            "medium",
+            "vengu",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 958",
+        "rarity": 7,
+        "description": "Test Item 958",
+        "point_value": 974,
+        "tags": [
+            "huge",
+            "tribal",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 959",
+        "rarity": 1,
+        "description": "Test Item 959",
+        "point_value": 589,
+        "tags": [
+            "tiny",
+            "tribal",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 960",
+        "rarity": 6,
+        "description": "Test Item 960",
+        "point_value": 242,
+        "tags": [
+            "small",
+            "ancient",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 961",
+        "rarity": 2,
+        "description": "Test Item 961",
+        "point_value": 982,
+        "tags": [
+            "tiny",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 962",
+        "rarity": 3,
+        "description": "Test Item 962",
+        "point_value": 313,
+        "tags": [
+            "medium",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 963",
+        "rarity": 4,
+        "description": "Test Item 963",
+        "point_value": 452,
+        "tags": [
+            "small",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 964",
+        "rarity": 3,
+        "description": "Test Item 964",
+        "point_value": 359,
+        "tags": [
+            "small",
+            "vengu",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 965",
+        "rarity": 6,
+        "description": "Test Item 965",
+        "point_value": 163,
+        "tags": [
+            "tiny",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 966",
+        "rarity": 4,
+        "description": "Test Item 966",
+        "point_value": 114,
+        "tags": [
+            "huge",
+            "ancient",
+            "booze"
+        ]
+    },
+    {
+        "name": "Test 967",
+        "rarity": 8,
+        "description": "Test Item 967",
+        "point_value": 303,
+        "tags": [
+            "medium",
+            "vengu",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 968",
+        "rarity": 4,
+        "description": "Test Item 968",
+        "point_value": 52,
+        "tags": [
+            "large",
+            "tribal",
+            "drugs"
+        ]
+    },
+    {
+        "name": "Test 969",
+        "rarity": 6,
+        "description": "Test Item 969",
+        "point_value": 235,
+        "tags": [
+            "huge",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 970",
+        "rarity": 2,
+        "description": "Test Item 970",
+        "point_value": 832,
+        "tags": [
+            "large",
+            "ancient",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 971",
+        "rarity": 2,
+        "description": "Test Item 971",
+        "point_value": 459,
+        "tags": [
+            "medium",
+            "tribal",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 972",
+        "rarity": 8,
+        "description": "Test Item 972",
+        "point_value": 28,
+        "tags": [
+            "medium",
+            "vengu",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 973",
+        "rarity": 4,
+        "description": "Test Item 973",
+        "point_value": 845,
+        "tags": [
+            "medium",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 974",
+        "rarity": 6,
+        "description": "Test Item 974",
+        "point_value": 941,
+        "tags": [
+            "large",
+            "ancient",
+            "weapon"
+        ]
+    },
+    {
+        "name": "Test 975",
+        "rarity": 7,
+        "description": "Test Item 975",
+        "point_value": 998,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 976",
+        "rarity": 7,
+        "description": "Test Item 976",
+        "point_value": 822,
+        "tags": [
+            "huge",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 977",
+        "rarity": 2,
+        "description": "Test Item 977",
+        "point_value": 331,
+        "tags": [
+            "tiny",
+            "tribal",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 978",
+        "rarity": 2,
+        "description": "Test Item 978",
+        "point_value": 865,
+        "tags": [
+            "small",
+            "ancient",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 979",
+        "rarity": 5,
+        "description": "Test Item 979",
+        "point_value": 996,
+        "tags": [
+            "small",
+            "vengu",
+            "literature"
+        ]
+    },
+    {
+        "name": "Test 980",
+        "rarity": 4,
+        "description": "Test Item 980",
+        "point_value": 588,
+        "tags": [
+            "tiny",
+            "ancient",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 981",
+        "rarity": 6,
+        "description": "Test Item 981",
+        "point_value": 669,
+        "tags": [
+            "medium",
+            "ancient",
+            "junk"
+        ]
+    },
+    {
+        "name": "Test 982",
+        "rarity": 8,
+        "description": "Test Item 982",
+        "point_value": 291,
+        "tags": [
+            "large",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 983",
+        "rarity": 8,
+        "description": "Test Item 983",
+        "point_value": 21,
+        "tags": [
+            "small",
+            "ancient",
+            "medicine"
+        ]
+    },
+    {
+        "name": "Test 984",
+        "rarity": 1,
+        "description": "Test Item 984",
+        "point_value": 104,
+        "tags": [
+            "medium",
+            "ancient",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 985",
+        "rarity": 4,
+        "description": "Test Item 985",
+        "point_value": 518,
+        "tags": [
+            "medium",
+            "tribal",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 986",
+        "rarity": 6,
+        "description": "Test Item 986",
+        "point_value": 764,
+        "tags": [
+            "huge",
+            "tribal",
+            "misc"
+        ]
+    },
+    {
+        "name": "Test 987",
+        "rarity": 8,
+        "description": "Test Item 987",
+        "point_value": 958,
+        "tags": [
+            "huge",
+            "vengu",
+            "armor"
+        ]
+    },
+    {
+        "name": "Test 988",
+        "rarity": 4,
+        "description": "Test Item 988",
+        "point_value": 143,
+        "tags": [
+            "small",
+            "ancient",
+            "food"
+        ]
+    },
+    {
+        "name": "Test 989",
+        "rarity": 3,
+        "description": "Test Item 989",
+        "point_value": 118,
+        "tags": [
+            "tiny",
+            "vengu",
+            "herb"
+        ]
+    },
+    {
+        "name": "Test 990",
+        "rarity": 2,
+        "description": "Test Item 990",
+        "point_value": 614,
+        "tags": [
+            "huge",
+            "tribal",
+            "liquid"
+        ]
+    },
+    {
+        "name": "Test 991",
+        "rarity": 8,
+        "description": "Test Item 991",
+        "point_value": 414,
+        "tags": [
+            "tiny",
+            "vengu",
+            "jewelry"
+        ]
+    },
+    {
+        "name": "Test 992",
+        "rarity": 6,
+        "description": "Test Item 992",
+        "point_value": 730,
+        "tags": [
+            "huge",
+            "ancient",
+            "tool"
+        ]
+    },
+    {
+        "name": "Test 993",
+        "rarity": 5,
+        "description": "Test Item 993",
+        "point_value": 577,
+        "tags": [
+            "medium",
+            "vengu",
+            "electronic"
+        ]
+    },
+    {
+        "name": "Test 994",
+        "rarity": 1,
+        "description": "Test Item 994",
+        "point_value": 479,
+        "tags": [
+            "huge",
+            "vengu",
+            "valuable"
+        ]
+    },
+    {
+        "name": "Test 995",
+        "rarity": 7,
+        "description": "Test Item 995",
+        "point_value": 280,
+        "tags": [
+            "huge",
+            "vengu",
+            "fuel"
+        ]
+    },
+    {
+        "name": "Test 996",
+        "rarity": 2,
+        "description": "Test Item 996",
+        "point_value": 850,
+        "tags": [
+            "medium",
+            "vengu",
+            "material"
+        ]
+    },
+    {
+        "name": "Test 997",
+        "rarity": 5,
+        "description": "Test Item 997",
+        "point_value": 473,
+        "tags": [
+            "large",
+            "ancient",
+            "art"
+        ]
+    },
+    {
+        "name": "Test 998",
+        "rarity": 5,
+        "description": "Test Item 998",
+        "point_value": 340,
+        "tags": [
+            "tiny",
+            "vengu",
+            "nanite"
+        ]
+    },
+    {
+        "name": "Test 999",
+        "rarity": 6,
+        "description": "Test Item 999",
+        "point_value": 770,
+        "tags": [
+            "tiny",
+            "ancient",
+            "clothing"
+        ]
+    },
+    {
+        "name": "Test 1000",
+        "rarity": 2,
+        "description": "Test Item 1000",
+        "point_value": 580,
+        "tags": [
+            "small",
+            "vengu",
+            "weapon"
+        ]
+    }
+]


### PR DESCRIPTION
## Summary
- replace `loot_items.json` with 1000 generated test items
- adjust a few specific items to keep tests functional

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421395d29083298891ac193d75fa1c