### PR TITLE
Display tags when generating loot

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ python loot_generator/loot_app.pyw
 ```
 
 This opens a window where you can generate loot, manage presets and maintain
-the list of available items.
+the list of available items. Generated loot now includes each item's tags in
+the output so you can easily see why an item was selected.
 
 ## Using Presets
 

--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -109,15 +109,16 @@ class LootGeneratorApp:
             for data in item_counts.values():
                 item = data["item"]
                 count = data["count"]
+                tags_str = ", ".join(item.tags)
                 if count > 1:
                     self.output_area.insert(
                         tk.END,
-                        f"{count}x {item.name} (Rarity: {item.rarity}) - {item.description} [{item.point_value} points each]\n",
+                        f"{count}x {item.name} (Rarity: {item.rarity}, Tags: {tags_str}) - {item.description} [{item.point_value} points each]\n",
                     )
                 else:
                     self.output_area.insert(
                         tk.END,
-                        f"{item.name} (Rarity: {item.rarity}) - {item.description} [{item.point_value} points]\n",
+                        f"{item.name} (Rarity: {item.rarity}, Tags: {tags_str}) - {item.description} [{item.point_value} points]\n",
                     )
         else:
             self.output_area.insert(tk.END, "No loot items matched your criteria.\n")


### PR DESCRIPTION
## Summary
- show tags in the generated loot output
- document that tags now appear when loot is generated

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684216206b7c8329bff50df901d0244c