### PR TITLE
Support bulk item input

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ a preset, or **Delete Preset** to remove it.
 
 ## Adding Items
 
-Click **Add Item** to open a dialog where you can enter the item's name,
-rarity, description, point value and tags. Items you add are saved to
-`loot_items.json` and become available for future loot generation.
+Click **Add Item** to open a dialog for a single item or **Bulk Add Items** to
+paste multiple items at once. In bulk mode, enter one item per line using the
+format `name|rarity|description|point_value|tag1,tag2`. All added items are
+saved to `loot_items.json` and become available for future loot generation.
 

--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -7,6 +7,7 @@ from utils import (
     load_presets,
     save_presets,
     generate_loot,
+    parse_items_text,
     LootItem,
     _resolve,
 )
@@ -75,7 +76,8 @@ class LootGeneratorApp:
         ttk.Button(frame, text="Add Item", command=self.add_item).grid(row=13, column=0, pady=5)
         ttk.Button(frame, text="Delete Item", command=self.delete_item).grid(row=13, column=1, pady=5)
 
-        ttk.Button(frame, text="Show Tags", command=self.show_tags).grid(row=14, column=0, columnspan=2, pady=5)
+        ttk.Button(frame, text="Bulk Add Items", command=self.bulk_add_items).grid(row=14, column=0, columnspan=2, pady=5)
+        ttk.Button(frame, text="Show Tags", command=self.show_tags).grid(row=15, column=0, columnspan=2, pady=5)
 
         frame.columnconfigure(1, weight=1)
         frame.rowconfigure(12, weight=1)
@@ -204,6 +206,31 @@ class LootGeneratorApp:
                 messagebox.showerror("Error", f"Invalid input: {e}")
 
         ttk.Button(add_window, text="Add Item", command=save_new_item).grid(row=len(fields), column=0, columnspan=2, pady=5)
+
+    def bulk_add_items(self):
+        bulk_window = tk.Toplevel(self.root)
+        bulk_window.title("Bulk Add Loot Items")
+
+        ttk.Label(
+            bulk_window,
+            text="Enter items one per line as name|rarity|description|point_value|tag1,tag2",
+        ).pack(pady=5)
+        text_area = tk.Text(bulk_window, width=60, height=10)
+        text_area.pack(padx=5, pady=5)
+
+        def save_bulk():
+            try:
+                items = parse_items_text(text_area.get("1.0", tk.END))
+                if not items:
+                    raise ValueError("No items provided")
+                self.loot_items.extend(items)
+                self.update_loot_file()
+                messagebox.showinfo("Success", f"Added {len(items)} items.")
+                bulk_window.destroy()
+            except Exception as e:
+                messagebox.showerror("Error", f"Invalid input: {e}")
+
+        ttk.Button(bulk_window, text="Add Items", command=save_bulk).pack(pady=5)
 
     def delete_item(self):
         item_names = [item.name for item in self.loot_items]

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -117,3 +117,27 @@ def generate_loot(
         total_points += item.point_value
 
     return loot
+
+
+def parse_items_text(text: str) -> List[LootItem]:
+    """Parse a bulk text string into ``LootItem`` objects.
+
+    Each non-empty line should contain five ``|`` separated fields in the
+    order ``name|rarity|description|point_value|tag1,tag2``. Tags are
+    comma-separated. Whitespace around fields is ignored.
+    """
+
+    items: List[LootItem] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) != 5:
+            raise ValueError("Each line must contain five '|' separated fields")
+        name, rarity_str, description, value_str, tags_str = parts
+        rarity = int(rarity_str)
+        point_value = int(value_str)
+        tags = [t.strip() for t in tags_str.split(",") if t.strip()]
+        items.append(LootItem(name, rarity, description, point_value, tags))
+
+    return items

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,3 +96,21 @@ def test_generate_loot_invalid_point_values_raise():
     ]
     with pytest.raises(ValueError):
         utils.generate_loot(items, points=5)
+
+
+def test_parse_items_text_valid():
+    text = "Sword|1|Sharp blade|10|weapon,melee"
+    items = utils.parse_items_text(text)
+    assert len(items) == 1
+    item = items[0]
+    assert item.name == "Sword"
+    assert item.rarity == 1
+    assert item.description == "Sharp blade"
+    assert item.point_value == 10
+    assert item.tags == ["weapon", "melee"]
+
+
+def test_parse_items_text_invalid():
+    text = "Bad|data"
+    with pytest.raises(ValueError):
+        utils.parse_items_text(text)


### PR DESCRIPTION
## Summary
- add `parse_items_text` utility for parsing `|` separated bulk item text
- allow bulk adding of loot items through new GUI dialog
- document bulk adding in the README
- test the new parsing function

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842219dc70c8329923ff880398cacad