### PR TITLE
Add material bulk import and tabbed UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ python loot_generator/loot_app.pyw
 ```
 
 This opens a window where you can generate loot, manage presets and maintain
-the list of available items. Generated loot now includes each item's tags in
-the output so you can easily see why an item was selected.
+the list of available items. Item and material management now live on separate
+"Items" and "Materials" tabs. Generated loot includes each item's tags so you
+can easily see why an item was selected.
 
 ## Using Presets
 
@@ -38,9 +39,9 @@ a preset, or **Delete Preset** to remove it.
 
 ## Adding Items
 
-Click **Add Item** to open a dialog for a single item or **Bulk Add Items** to
-paste multiple items at once. In bulk mode, enter one item per line using the
-format `name|rarity|description|point_value|tag1,tag2`. All added items are
+Use the **Items** tab to manage loot items. Click **Add Item** for a single
+entry or **Bulk Add Items** to paste many at once. In bulk mode, enter one item
+per line as `name|rarity|description|point_value|tag1,tag2`. All added items are
 saved to `loot_items.json` and become available for future loot generation.
 
 ## Managing Materials
@@ -48,8 +49,9 @@ saved to `loot_items.json` and become available for future loot generation.
 Some item names may include placeholders such as `[Metal]` or `[Stone/o]` which
 are replaced with a random material when loot is generated. Materials are stored
 in `materials.json` and each has a name, point modifier and type
-(`Metal`, `Stone`, `Wood` or `Fabric`). Use **Add Material** and **Delete
-Material** in the GUI to manage this list. Optional placeholders denoted with
-`/o` may resolve to an empty string, allowing items like `[Metal] [Stone/o]
-Earring` to generate as "Steel Diamond Earring" or simply "Copper Earring".
+(`Metal`, `Stone`, `Wood` or `Fabric`). The **Materials** tab provides
+**Add Material**, **Bulk Add Materials** and **Delete Material** actions. Optional
+placeholders denoted with `/o` may resolve to an empty string, allowing items
+like `[Metal] [Stone/o] Earring` to generate as "Steel Diamond Earring" or
+simply "Copper Earring".
 

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -201,3 +201,24 @@ def parse_items_text(text: str) -> List[LootItem]:
         items.append(LootItem(name, rarity, description, point_value, tags))
 
     return items
+
+
+def parse_materials_text(text: str) -> List[Material]:
+    """Parse a bulk text string into ``Material`` objects.
+
+    Each non-empty line should contain three ``|`` separated fields in the
+    order ``name|modifier|type``. Whitespace around fields is ignored.
+    """
+
+    materials: List[Material] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) != 3:
+            raise ValueError("Each line must contain three '|' separated fields")
+        name, modifier_str, type_str = parts
+        modifier = float(modifier_str)
+        materials.append(Material(name, modifier, type_str))
+
+    return materials

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,3 +149,19 @@ def test_generate_loot_with_materials():
     random.seed(1)
     loot = utils.generate_loot(items, points=10, materials=materials)
     assert loot[0].name == 'Iron Dagger'
+
+
+def test_parse_materials_text_valid():
+    text = "Steel|1.2|Metal"
+    mats = utils.parse_materials_text(text)
+    assert len(mats) == 1
+    m = mats[0]
+    assert m.name == "Steel"
+    assert m.modifier == 1.2
+    assert m.type == "Metal"
+
+
+def test_parse_materials_text_invalid():
+    text = "Bad|data"
+    with pytest.raises(ValueError):
+        utils.parse_materials_text(text)


### PR DESCRIPTION
## Summary
- support bulk adding materials with `parse_materials_text`
- restructure the GUI into Generate, Items and Materials tabs
- add Bulk Add Materials functionality
- update documentation for the new tabs and bulk material feature
- test parsing of bulk materials

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842582e3e948329bec2f4d8209fe8b5