### PR TITLE
Support multiple material types

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ saved to `loot_items.json` and become available for future loot generation.
 ## Managing Materials
 
 Some item names may include placeholders such as `[Metal]` or `[Stone/o]` which
-are replaced with a random material when loot is generated. Materials are stored
-in `materials.json` and each has a name, point modifier and type
-(`Metal`, `Stone`, `Wood` or `Fabric`). The **Materials** tab provides
-**Add Material**, **Bulk Add Materials** and **Delete Material** actions. Optional
-placeholders denoted with `/o` may resolve to an empty string, allowing items
-like `[Metal] [Stone/o] Earring` to generate as "Steel Diamond Earring" or
-simply "Copper Earring".
+are replaced with a random material when loot is generated. Multiple material
+types can be combined with slashes, e.g. `[Wood/Metal/Stone]`, in which case a
+material of any listed type may be chosen. Materials are stored in
+`materials.json` and each has a name, point modifier and type (`Metal`, `Stone`,
+`Wood` or `Fabric`). The **Materials** tab provides **Add Material**, **Bulk Add
+Materials** and **Delete Material** actions. Optional placeholders denoted with
+`/o` may resolve to an empty string, allowing items like `[Metal] [Stone/o]
+Earring` or `[Wood/Metal/o] Shield` to generate with or without the material
+name.
 

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -154,20 +154,24 @@ def generate_loot(
 def resolve_material_placeholders(name: str, value: int, materials: List[Material]) -> (str, int):
     """Replace material placeholders in ``name`` using provided materials.
 
-    Placeholders are of the form ``[Metal]`` or ``[Metal/o]``. The optional
-    variant (``/o``) may be replaced with an empty string with 50% probability.
-    ``value`` is modified by each material's ``modifier``.
+    Placeholders are of the form ``[Metal]`` or ``[Metal/o]``. Multiple material
+    types can be provided by separating them with ``/`` such as
+    ``[Wood/Metal/Stone]``. The optional variant (``/o``) may be combined with
+    multiple types (e.g. ``[Wood/Metal/o]``) and may be replaced with an empty
+    string with 50% probability. ``value`` is modified by each material's
+    ``modifier``.
     """
-    pattern = re.compile(r"\[(Metal|Stone|Wood|Fabric)(/o)?\]")
+    pattern = re.compile(r"\[([A-Za-z/]+?)(?:(/o))?\]")
     modifiers = 1.0
 
     def repl(match: re.Match) -> str:
         nonlocal modifiers
-        m_type, optional = match.group(1), match.group(2)
+        types_str, optional = match.group(1), match.group(2)
         if optional:
             if random.random() < 0.5:
                 return ""
-        options = [m for m in materials if m.type.lower() == m_type.lower()]
+        types = [t.strip() for t in types_str.split("/") if t.strip()]
+        options = [m for m in materials if m.type.lower() in {t.lower() for t in types}]
         if not options:
             return ""
         mat = random.choice(options)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,6 +143,30 @@ def test_resolve_material_placeholders_optional_none():
     assert value == 8
 
 
+def test_resolve_material_placeholders_multiple_types():
+    random.seed(0)
+    materials = [
+        utils.Material("Iron", 1.2, "Metal"),
+        utils.Material("Oak", 1.3, "Wood"),
+        utils.Material("Ruby", 1.4, "Stone"),
+    ]
+    name, value = utils.resolve_material_placeholders("[Wood/Metal/Stone] Ring", 10, materials)
+    assert name == "Oak Ring"
+    assert value == 13
+
+
+def test_resolve_material_placeholders_multiple_types_optional_none():
+    random.seed(1)
+    materials = [
+        utils.Material("Steel", 1.2, "Metal"),
+        utils.Material("Birch", 1.1, "Wood"),
+    ]
+    name, value = utils.resolve_material_placeholders("Ring [Metal/Wood/o]", 10, materials)
+    # With seed 1 optional placeholder is removed
+    assert name == "Ring"
+    assert value == 10
+
+
 def test_generate_loot_with_materials():
     items = [utils.LootItem('[Metal] Dagger', 1, '', 10, ['weapon'])]
     materials = [utils.Material('Iron', 1.0, 'Metal')]


### PR DESCRIPTION
## Summary
- add slash-separated material types in placeholders
- clarify placeholder usage in README
- test multi-type placeholder behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842646895e0832989fd7d6ba8a6e32f