### PR TITLE
Restore feature parity

### DIFF
--- a/LootGenWinForms/AddItemForm.cs
+++ b/LootGenWinForms/AddItemForm.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace LootGenWinForms
+{
+    public class AddItemForm : Form
+    {
+        private readonly TextBox txtName = new();
+        private readonly NumericUpDown numRarity = new();
+        private readonly TextBox txtDesc = new();
+        private readonly NumericUpDown numValue = new();
+        private readonly TextBox txtTags = new();
+        private readonly Button btnOk = new() { Text = "OK", DialogResult = DialogResult.OK };
+        private readonly Button btnCancel = new() { Text = "Cancel", DialogResult = DialogResult.Cancel };
+
+        public LootItem? Result { get; private set; }
+
+        public AddItemForm()
+        {
+            Text = "Add Item";
+            Width = 300;
+            Height = 250;
+            var table = new TableLayoutPanel { Dock = DockStyle.Fill, RowCount = 6, ColumnCount = 2 };
+            Controls.Add(table);
+            table.Controls.Add(new Label { Text = "Name" }, 0, 0);
+            table.Controls.Add(txtName, 1, 0);
+            table.Controls.Add(new Label { Text = "Rarity" }, 0, 1);
+            numRarity.Minimum = 1; numRarity.Maximum = 100;
+            table.Controls.Add(numRarity, 1, 1);
+            table.Controls.Add(new Label { Text = "Description" }, 0, 2);
+            table.Controls.Add(txtDesc, 1, 2);
+            table.Controls.Add(new Label { Text = "Point Value" }, 0, 3);
+            numValue.Minimum = 1; numValue.Maximum = 1000;
+            table.Controls.Add(numValue, 1, 3);
+            table.Controls.Add(new Label { Text = "Tags" }, 0, 4);
+            table.Controls.Add(txtTags, 1, 4);
+            var panel = new FlowLayoutPanel { Dock = DockStyle.Fill, FlowDirection = FlowDirection.RightToLeft };
+            panel.Controls.Add(btnCancel);
+            panel.Controls.Add(btnOk);
+            table.Controls.Add(panel, 0, 5);
+            table.SetColumnSpan(panel, 2);
+            AcceptButton = btnOk;
+            CancelButton = btnCancel;
+            btnOk.Click += (_, _) =>
+            {
+                Result = new LootItem(
+                    txtName.Text,
+                    (int)numRarity.Value,
+                    txtDesc.Text,
+                    (int)numValue.Value,
+                    txtTags.Text.Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToList());
+            };
+        }
+    }
+}

--- a/LootGenWinForms/AddMaterialForm.cs
+++ b/LootGenWinForms/AddMaterialForm.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace LootGenWinForms
+{
+    public class AddMaterialForm : Form
+    {
+        private readonly TextBox txtName = new();
+        private readonly NumericUpDown numModifier = new();
+        private readonly TextBox txtType = new();
+        private readonly Button btnOk = new() { Text = "OK", DialogResult = DialogResult.OK };
+        private readonly Button btnCancel = new() { Text = "Cancel", DialogResult = DialogResult.Cancel };
+
+        public Material? Result { get; private set; }
+
+        public AddMaterialForm()
+        {
+            Text = "Add Material";
+            Width = 300;
+            Height = 180;
+            var table = new TableLayoutPanel { Dock = DockStyle.Fill, RowCount = 4, ColumnCount = 2 };
+            Controls.Add(table);
+            table.Controls.Add(new Label { Text = "Name" }, 0, 0);
+            table.Controls.Add(txtName, 1, 0);
+            table.Controls.Add(new Label { Text = "Modifier" }, 0, 1);
+            numModifier.DecimalPlaces = 2; numModifier.Minimum = 0; numModifier.Maximum = 100;
+            numModifier.Increment = 0.1M; table.Controls.Add(numModifier, 1, 1);
+            table.Controls.Add(new Label { Text = "Type" }, 0, 2);
+            table.Controls.Add(txtType, 1, 2);
+            var panel = new FlowLayoutPanel { Dock = DockStyle.Fill, FlowDirection = FlowDirection.RightToLeft };
+            panel.Controls.Add(btnCancel); panel.Controls.Add(btnOk);
+            table.Controls.Add(panel, 0, 3); table.SetColumnSpan(panel, 2);
+            AcceptButton = btnOk; CancelButton = btnCancel;
+            btnOk.Click += (_, _) =>
+            {
+                Result = new Material(txtName.Text, (double)numModifier.Value, txtType.Text);
+            };
+        }
+    }
+}

--- a/LootGenWinForms/BulkAddForm.cs
+++ b/LootGenWinForms/BulkAddForm.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace LootGenWinForms
+{
+    public class BulkAddForm<T> : Form
+    {
+        private readonly TextBox textArea = new() { Multiline = true, ScrollBars = ScrollBars.Vertical, Dock = DockStyle.Fill };
+        private readonly Button btnOk = new() { Text = "Add", DialogResult = DialogResult.OK };
+        private readonly Button btnCancel = new() { Text = "Cancel", DialogResult = DialogResult.Cancel };
+        private readonly Func<string, List<T>> _parser;
+        public List<T> Results { get; } = new();
+
+        public BulkAddForm(string title, string instructions, Func<string, List<T>> parser)
+        {
+            _parser = parser;
+            Text = title;
+            Width = 500;
+            Height = 300;
+            var table = new TableLayoutPanel { Dock = DockStyle.Fill, RowCount = 3, ColumnCount = 1 };
+            Controls.Add(table);
+            table.Controls.Add(new Label { Text = instructions }, 0, 0);
+            table.Controls.Add(textArea, 0, 1);
+            var panel = new FlowLayoutPanel { Dock = DockStyle.Fill, FlowDirection = FlowDirection.RightToLeft };
+            panel.Controls.Add(btnCancel); panel.Controls.Add(btnOk);
+            table.Controls.Add(panel, 0, 2);
+            AcceptButton = btnOk; CancelButton = btnCancel;
+            btnOk.Click += (_, _) =>
+            {
+                Results.AddRange(_parser(textArea.Text));
+            };
+        }
+    }
+}

--- a/LootGenWinForms/MainForm.cs
+++ b/LootGenWinForms/MainForm.cs
@@ -12,12 +12,14 @@ namespace LootGenWinForms
     {
         private readonly List<LootItem> _items;
         private readonly List<Material> _materials;
+        private readonly Dictionary<string, Preset> _presets;
 
         public MainForm()
         {
             InitializeComponent();
             _items = DataLoader.LoadLootItems();
             _materials = DataLoader.LoadMaterials();
+            _presets = DataLoader.LoadPresets();
         }
 
         private void OnGenerate(object? sender, EventArgs e)
@@ -41,64 +43,272 @@ namespace LootGenWinForms
 
     public partial class MainForm
     {
+        private TabControl tabs = new TabControl();
+
+        // generate tab controls
         private NumericUpDown numericPoints = new NumericUpDown();
         private TextBox textInclude = new TextBox();
         private TextBox textExclude = new TextBox();
         private NumericUpDown numericMax = new NumericUpDown();
         private NumericUpDown numericMin = new NumericUpDown();
+        private TextBox textPresetSearch = new TextBox();
+        private ListBox listPresets = new ListBox();
+        private Button btnLoadPreset = new Button();
+        private Button btnSavePreset = new Button();
+        private Button btnDeletePreset = new Button();
         private Button btnGenerate = new Button();
+        private Button btnShowTags = new Button();
         private TextBox textOutput = new TextBox();
+
+        // item tab controls
+        private DataGridView gridItems = new DataGridView();
+        private Button btnAddItem = new Button();
+        private Button btnDelItem = new Button();
+        private Button btnBulkItems = new Button();
+        private Button btnSaveItems = new Button();
+
+        // material tab controls
+        private DataGridView gridMaterials = new DataGridView();
+        private Button btnAddMat = new Button();
+        private Button btnDelMat = new Button();
+        private Button btnBulkMat = new Button();
+        private Button btnSaveMat = new Button();
 
         private void InitializeComponent()
         {
             Text = "Loot Generator";
-            Width = 600;
-            Height = 400;
+            Width = 800;
+            Height = 600;
 
-            var table = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 2 };
-            Controls.Add(table);
+            tabs.Dock = DockStyle.Fill;
+            Controls.Add(tabs);
 
-            table.Controls.Add(new Label { Text = "Loot Points" }, 0, 0);
+            var tabGenerate = new TabPage("Generate");
+            var tabItems = new TabPage("Items");
+            var tabMats = new TabPage("Materials");
+            tabs.TabPages.AddRange(new[] { tabGenerate, tabItems, tabMats });
+
+            // --- generate tab ---
+            var gTable = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 2 };
+            tabGenerate.Controls.Add(gTable);
+            gTable.Controls.Add(new Label { Text = "Loot Points" }, 0, 0);
             numericPoints.Maximum = 1000;
-            table.Controls.Add(numericPoints, 1, 0);
+            gTable.Controls.Add(numericPoints, 1, 0);
 
-            table.Controls.Add(new Label { Text = "Include Tags" }, 0, 1);
-            table.Controls.Add(textInclude, 1, 1);
+            gTable.Controls.Add(new Label { Text = "Include Tags" }, 0, 1);
+            gTable.Controls.Add(textInclude, 1, 1);
 
-            table.Controls.Add(new Label { Text = "Exclude Tags" }, 0, 2);
-            table.Controls.Add(textExclude, 1, 2);
+            gTable.Controls.Add(new Label { Text = "Exclude Tags" }, 0, 2);
+            gTable.Controls.Add(textExclude, 1, 2);
 
-            table.Controls.Add(new Label { Text = "Max Rarity" }, 0, 3);
+            gTable.Controls.Add(new Label { Text = "Max Rarity" }, 0, 3);
             numericMax.Maximum = 100;
-            table.Controls.Add(numericMax, 1, 3);
+            gTable.Controls.Add(numericMax, 1, 3);
 
-            table.Controls.Add(new Label { Text = "Min Rarity" }, 0, 4);
+            gTable.Controls.Add(new Label { Text = "Min Rarity" }, 0, 4);
             numericMin.Maximum = 100;
-            table.Controls.Add(numericMin, 1, 4);
+            gTable.Controls.Add(numericMin, 1, 4);
+
+            gTable.Controls.Add(new Label { Text = "Search Presets" }, 0, 5);
+            textPresetSearch.TextChanged += (_, _) => UpdatePresetList();
+            gTable.Controls.Add(textPresetSearch, 1, 5);
+
+            gTable.Controls.Add(new Label { Text = "Presets" }, 0, 6);
+            listPresets.Height = 80;
+            gTable.Controls.Add(listPresets, 1, 6);
+
+            var presetBtnPanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, Dock = DockStyle.Fill };
+            btnLoadPreset.Text = "Load"; btnLoadPreset.Click += (_, _) => LoadSelectedPreset();
+            btnSavePreset.Text = "Save"; btnSavePreset.Click += (_, _) => SaveCurrentPreset();
+            btnDeletePreset.Text = "Delete"; btnDeletePreset.Click += (_, _) => DeleteSelectedPreset();
+            presetBtnPanel.Controls.AddRange(new Control[] { btnLoadPreset, btnSavePreset, btnDeletePreset });
+            gTable.Controls.Add(presetBtnPanel, 0, 7);
+            gTable.SetColumnSpan(presetBtnPanel, 2);
 
             btnGenerate.Text = "Generate";
             btnGenerate.Click += OnGenerate;
-            table.Controls.Add(btnGenerate, 0, 5);
-            table.SetColumnSpan(btnGenerate, 2);
+            btnShowTags.Text = "Show Tags"; btnShowTags.Click += (_, _) => ShowAllTags();
+            var genButtons = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, Dock = DockStyle.Fill };
+            genButtons.Controls.AddRange(new Control[] { btnGenerate, btnShowTags });
+            gTable.Controls.Add(genButtons, 0, 8);
+            gTable.SetColumnSpan(genButtons, 2);
 
             textOutput.Multiline = true;
             textOutput.ScrollBars = ScrollBars.Vertical;
             textOutput.Dock = DockStyle.Fill;
-            table.Controls.Add(textOutput, 0, 6);
-            table.SetColumnSpan(textOutput, 2);
-            table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            table.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+            gTable.Controls.Add(textOutput, 0, 9);
+            gTable.SetColumnSpan(textOutput, 2);
+            for (int i = 0; i < 10; i++) gTable.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            gTable.RowStyles[9] = new RowStyle(SizeType.Percent, 100);
+
+            // --- items tab ---
+            var iTable = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 2 };
+            tabItems.Controls.Add(iTable);
+            gridItems.Dock = DockStyle.Fill;
+            gridItems.AutoGenerateColumns = true;
+            iTable.Controls.Add(gridItems, 0, 0);
+            iTable.SetColumnSpan(gridItems, 2);
+            var itemBtnPanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, Dock = DockStyle.Fill };
+            btnAddItem.Text = "Add"; btnAddItem.Click += (_, _) => AddItem();
+            btnDelItem.Text = "Delete"; btnDelItem.Click += (_, _) => DeleteSelectedItem();
+            btnBulkItems.Text = "Bulk Add"; btnBulkItems.Click += (_, _) => BulkAddItems();
+            btnSaveItems.Text = "Save"; btnSaveItems.Click += (_, _) => SaveItems();
+            itemBtnPanel.Controls.AddRange(new Control[] { btnAddItem, btnDelItem, btnBulkItems, btnSaveItems });
+            iTable.Controls.Add(itemBtnPanel, 0, 1);
+            iTable.SetColumnSpan(itemBtnPanel, 2);
+            iTable.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+            iTable.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+            // --- materials tab ---
+            var mTable = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 2 };
+            tabMats.Controls.Add(mTable);
+            gridMaterials.Dock = DockStyle.Fill;
+            gridMaterials.AutoGenerateColumns = true;
+            mTable.Controls.Add(gridMaterials, 0, 0);
+            mTable.SetColumnSpan(gridMaterials, 2);
+            var matBtnPanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, Dock = DockStyle.Fill };
+            btnAddMat.Text = "Add"; btnAddMat.Click += (_, _) => AddMaterial();
+            btnDelMat.Text = "Delete"; btnDelMat.Click += (_, _) => DeleteSelectedMaterial();
+            btnBulkMat.Text = "Bulk Add"; btnBulkMat.Click += (_, _) => BulkAddMaterials();
+            btnSaveMat.Text = "Save"; btnSaveMat.Click += (_, _) => SaveMaterials();
+            matBtnPanel.Controls.AddRange(new Control[] { btnAddMat, btnDelMat, btnBulkMat, btnSaveMat });
+            mTable.Controls.Add(matBtnPanel, 0, 1);
+            mTable.SetColumnSpan(matBtnPanel, 2);
+            mTable.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+            mTable.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+            // bind grids
+            gridItems.DataSource = new BindingSource { DataSource = _items };
+            gridMaterials.DataSource = new BindingSource { DataSource = _materials };
+            UpdatePresetList();
+        }
+
+        private void AddItem()
+        {
+            using var f = new AddItemForm();
+            if (f.ShowDialog() == DialogResult.OK && f.Result != null)
+            {
+                _items.Add(f.Result);
+                gridItems.DataSource = new BindingSource { DataSource = _items };
+            }
+        }
+
+        private void DeleteSelectedItem()
+        {
+            if (gridItems.CurrentRow?.DataBoundItem is LootItem item)
+            {
+                _items.Remove(item);
+                gridItems.DataSource = new BindingSource { DataSource = _items };
+            }
+        }
+
+        private void BulkAddItems()
+        {
+            using var f = new BulkAddForm<LootItem>(
+                "Bulk Add Items",
+                "Enter items as name|rarity|description|value|tag1,tag2",
+                DataLoader.ParseItemsText);
+            if (f.ShowDialog() == DialogResult.OK)
+            {
+                _items.AddRange(f.Results);
+                gridItems.DataSource = new BindingSource { DataSource = _items };
+            }
+        }
+
+        private void SaveItems()
+        {
+            DataLoader.SaveLootItems(_items);
+        }
+
+        private void AddMaterial()
+        {
+            using var f = new AddMaterialForm();
+            if (f.ShowDialog() == DialogResult.OK && f.Result != null)
+            {
+                _materials.Add(f.Result);
+                gridMaterials.DataSource = new BindingSource { DataSource = _materials };
+            }
+        }
+
+        private void DeleteSelectedMaterial()
+        {
+            if (gridMaterials.CurrentRow?.DataBoundItem is Material mat)
+            {
+                _materials.Remove(mat);
+                gridMaterials.DataSource = new BindingSource { DataSource = _materials };
+            }
+        }
+
+        private void BulkAddMaterials()
+        {
+            using var f = new BulkAddForm<Material>(
+                "Bulk Add Materials",
+                "Enter materials as name|modifier|type",
+                DataLoader.ParseMaterialsText);
+            if (f.ShowDialog() == DialogResult.OK)
+            {
+                _materials.AddRange(f.Results);
+                gridMaterials.DataSource = new BindingSource { DataSource = _materials };
+            }
+        }
+
+        private void SaveMaterials()
+        {
+            DataLoader.SaveMaterials(_materials);
+        }
+
+        private void ShowAllTags()
+        {
+            var tags = _items.SelectMany(i => i.Tags).Distinct().OrderBy(t => t);
+            MessageBox.Show(string.Join(", ", tags), "Tags");
+        }
+
+        private void UpdatePresetList()
+        {
+            var term = textPresetSearch.Text?.Trim().ToLowerInvariant() ?? string.Empty;
+            listPresets.Items.Clear();
+            foreach (var name in _presets.Keys.Where(n => n.ToLowerInvariant().Contains(term)))
+                listPresets.Items.Add(name);
+        }
+
+        private void LoadSelectedPreset()
+        {
+            if (listPresets.SelectedItem is string name && _presets.TryGetValue(name, out var p))
+            {
+                numericPoints.Value = p.LootPoints;
+                textInclude.Text = string.Join(", ", p.IncludeTags);
+                textExclude.Text = string.Join(", ", p.ExcludeTags);
+            }
+        }
+
+        private void SaveCurrentPreset()
+        {
+            var name = Microsoft.VisualBasic.Interaction.InputBox("Preset name?", "Save Preset", "Preset");
+            if (string.IsNullOrWhiteSpace(name)) return;
+            var preset = new Preset(
+                (int)numericPoints.Value,
+                ParseTags(textInclude.Text) ?? new List<string>(),
+                ParseTags(textExclude.Text) ?? new List<string>());
+            _presets[name] = preset;
+            DataLoader.SavePresets(_presets);
+            UpdatePresetList();
+        }
+
+        private void DeleteSelectedPreset()
+        {
+            if (listPresets.SelectedItem is string name && _presets.Remove(name))
+            {
+                DataLoader.SavePresets(_presets);
+                UpdatePresetList();
+            }
         }
     }
 
     public record LootItem(string Name, int Rarity, string Description, int PointValue, List<string> Tags);
 
     public record Material(string Name, double Modifier, string Type);
+
+    public record Preset(int LootPoints, List<string> IncludeTags, List<string> ExcludeTags);
 
     public static class DataLoader
     {
@@ -139,6 +349,67 @@ namespace LootGenWinForms
                     mat.GetProperty("name").GetString() ?? "",
                     mat.GetProperty("modifier").GetDouble(),
                     mat.GetProperty("type").GetString() ?? ""));
+            }
+            return list;
+        }
+
+        public static Dictionary<string, Preset> LoadPresets()
+        {
+            var path = DataPath("presets.json");
+            if (!File.Exists(path)) return new();
+            using var stream = File.OpenRead(path);
+            var presets = JsonSerializer.Deserialize<Dictionary<string, Preset>>(stream);
+            return presets ?? new();
+        }
+
+        public static void SavePresets(Dictionary<string, Preset> presets)
+        {
+            var path = DataPath("presets.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var opts = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(path, JsonSerializer.Serialize(presets, opts));
+        }
+
+        public static void SaveLootItems(List<LootItem> items)
+        {
+            var path = DataPath("loot_items.json");
+            var tags = items.SelectMany(i => i.Tags).Distinct().OrderBy(t => t).ToList();
+            var opts = new JsonSerializerOptions { WriteIndented = true };
+            var obj = new { items, tags };
+            File.WriteAllText(path, JsonSerializer.Serialize(obj, opts));
+        }
+
+        public static void SaveMaterials(List<Material> materials)
+        {
+            var path = DataPath("materials.json");
+            var opts = new JsonSerializerOptions { WriteIndented = true };
+            var obj = new { materials };
+            File.WriteAllText(path, JsonSerializer.Serialize(obj, opts));
+        }
+
+        public static List<LootItem> ParseItemsText(string text)
+        {
+            var list = new List<LootItem>();
+            foreach (var line in text.Split('\n'))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var parts = line.Split('|');
+                if (parts.Length != 5) throw new FormatException("Invalid item line");
+                var tags = parts[4].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToList();
+                list.Add(new LootItem(parts[0].Trim(), int.Parse(parts[1]), parts[2].Trim(), int.Parse(parts[3]), tags));
+            }
+            return list;
+        }
+
+        public static List<Material> ParseMaterialsText(string text)
+        {
+            var list = new List<Material>();
+            foreach (var line in text.Split('\n'))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var parts = line.Split('|');
+                if (parts.Length != 3) throw new FormatException("Invalid material line");
+                list.Add(new Material(parts[0].Trim(), double.Parse(parts[1]), parts[2].Trim()));
             }
             return list;
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loot Generator
 
-A simple Windows Forms application for generating loot using a point based system. The program loads item and material definitions from JSON files and lets you filter by tags and rarity.
+A Windows Forms application for generating loot using a point based system. The program now mirrors all features of the original Python version. Items and materials can be edited through dedicated tabs and presets can be saved and loaded.
 
 ## Building
 
@@ -16,6 +16,12 @@ dotnet build
 
 After building, run the generated executable in the `bin/` directory or start the project from Visual Studio.
 
-The main window allows you to enter the number of loot points, include or exclude tags and limit item rarity. Click **Generate** to produce a list of loot items.
+The main window contains three tabs:
+
+* **Generate** – configure loot generation, manage presets and view all available tags.
+* **Items** – view, add or remove loot items and bulk import using the `name|rarity|description|value|tags` format.
+* **Materials** – edit material definitions with optional bulk import using the `name|modifier|type` format.
+
+Click **Generate** to produce a list of loot items. Material placeholders in item names (e.g. `[Metal/o] Sword`) are resolved automatically.
 
 All data files are located in the `data` directory and are copied next to the executable on build.


### PR DESCRIPTION
## Summary
- add forms for adding items and materials
- implement bulk-add functionality
- restore preset loading and saving
- show tags and tabbed UI
- document new UI in README

## Testing
- `dotnet build -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684360a29d208329a78cf3812200693c