### PR TITLE
Fix NullReference in preset list loading

### DIFF
--- a/LootGenWinForms/MainForm.cs
+++ b/LootGenWinForms/MainForm.cs
@@ -16,10 +16,13 @@ namespace LootGenWinForms
 
         public MainForm()
         {
-            InitializeComponent();
+            // Load data before initializing UI components so that bindings
+            // and preset lists have valid sources during initialization.
             _items = DataLoader.LoadLootItems();
             _materials = DataLoader.LoadMaterials();
             _presets = DataLoader.LoadPresets();
+
+            InitializeComponent();
         }
 
         private void OnGenerate(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- load loot, materials, and presets before constructing UI

This prevents `_presets` from being null when `InitializeComponent` calls `UpdatePresetList`.

## Testing
- `dotnet build LootGenWinForms/LootGenWinForms.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684362638f9083298c5d5a1d3b1ea1a5